### PR TITLE
feat: pagos y notificaciones de servicio

### DIFF
--- a/API/migrations/20260705_create_announcements.js
+++ b/API/migrations/20260705_create_announcements.js
@@ -1,0 +1,26 @@
+exports.up = async function (knex) {
+  await knex.schema.createTable('announcements', function (table) {
+    table.increments('id').primary();
+    table.text('message').notNullable().defaultTo('');
+    table.boolean('enabled').notNullable().defaultTo(false);
+    table.integer('version').notNullable().defaultTo(1);
+    table.integer('updated_by').nullable();
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+  });
+
+  // Ensure a single config row exists (id = 1).
+  const existing = await knex('announcements').where({ id: 1 }).first();
+  if (!existing) {
+    await knex('announcements').insert({
+      id: 1,
+      message: '',
+      enabled: false,
+      version: 1,
+    });
+  }
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('announcements');
+};

--- a/API/migrations/20260705_create_service_payments.js
+++ b/API/migrations/20260705_create_service_payments.js
@@ -1,0 +1,47 @@
+exports.up = async function (knex) {
+  const exists = await knex.schema.hasTable('service_payments');
+  if (!exists) {
+    await knex.schema.createTable('service_payments', function (table) {
+      table.increments('id').primary();
+      table.integer('user_id').notNullable().index();
+      // Periodo que cubre el pago, formato 'YYYY-MM' (siempre vence el 15).
+      table.string('period').notNullable();
+      // pending | confirmed | rejected
+      table.string('status').notNullable().defaultTo('pending');
+      // card | transfer
+      table.string('method').nullable();
+      table.decimal('amount', 12, 2).nullable();
+      table.string('reference').nullable();
+      // Comprobante de transferencia (dataURL base64 de imagen o PDF).
+      table.text('proof').nullable();
+      table.string('proof_mime').nullable();
+      table.string('proof_name').nullable();
+      table.text('note').nullable();
+      table.integer('reviewed_by').nullable();
+      table.timestamp('confirmed_at').nullable();
+      table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+      table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+      table.index(['user_id', 'period']);
+    });
+    return;
+  }
+
+  // La tabla ya existe: agregar columnas faltantes de forma idempotente.
+  const columns = ['proof_mime', 'proof_name', 'note'];
+  for (const column of columns) {
+    const hasColumn = await knex.schema.hasColumn('service_payments', column);
+    if (!hasColumn) {
+      await knex.schema.alterTable('service_payments', (table) => {
+        if (column === 'note') {
+          table.text('note').nullable();
+        } else {
+          table.string(column).nullable();
+        }
+      });
+    }
+  }
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('service_payments');
+};

--- a/API/migrations/20260706_create_subscription_config.js
+++ b/API/migrations/20260706_create_subscription_config.js
@@ -1,0 +1,23 @@
+exports.up = async function (knex) {
+  const exists = await knex.schema.hasTable('subscription_config');
+  if (exists) {
+    return;
+  }
+
+  await knex.schema.createTable('subscription_config', function (table) {
+    // Un registro por cliente (user_id = usuario.id).
+    table.integer('user_id').primary();
+    // Monto mensual del servicio (lista de precios por cliente).
+    table.decimal('amount', 12, 2).notNullable().defaultTo(0);
+    table.boolean('active').notNullable().defaultTo(true);
+    // Reservado para el cobro recurrente con tarjeta (Wompi) - fase 2.
+    table.string('card_token').nullable();
+    table.string('card_last4').nullable();
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+    table.timestamp('updated_at').notNullable().defaultTo(knex.fn.now());
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('subscription_config');
+};

--- a/API/migrations/_manual_payments.sql
+++ b/API/migrations/_manual_payments.sql
@@ -1,0 +1,58 @@
+-- =============================================================
+-- Pagos de servicio - SQL manual (Postgres)
+-- Idempotente: se puede correr varias veces sin romper nada.
+-- Las migraciones knex hacen lo mismo automáticamente en el deploy;
+-- este archivo es para aplicarlo a la DB en vivo de una vez.
+-- =============================================================
+
+-- 1) Tabla de pagos del servicio (transferencia / tarjeta) --------------------
+CREATE TABLE IF NOT EXISTS service_payments (
+    id          SERIAL PRIMARY KEY,
+    user_id     INTEGER NOT NULL,
+    period      VARCHAR(7) NOT NULL,              -- 'YYYY-MM' (vence el 15)
+    status      VARCHAR(20) NOT NULL DEFAULT 'pending', -- pending | confirmed | rejected
+    method      VARCHAR(20),                      -- card | transfer
+    amount      NUMERIC(12,2),
+    reference   VARCHAR(255),
+    proof       TEXT,                             -- dataURL base64 (imagen o PDF)
+    proof_mime  VARCHAR(255),
+    proof_name  VARCHAR(255),
+    note        TEXT,
+    reviewed_by INTEGER,
+    confirmed_at TIMESTAMP,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- Por si la tabla ya existía sin estas columnas:
+ALTER TABLE service_payments ADD COLUMN IF NOT EXISTS proof_mime  VARCHAR(255);
+ALTER TABLE service_payments ADD COLUMN IF NOT EXISTS proof_name  VARCHAR(255);
+ALTER TABLE service_payments ADD COLUMN IF NOT EXISTS note        TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_service_payments_user      ON service_payments (user_id);
+CREATE INDEX IF NOT EXISTS idx_service_payments_user_prd  ON service_payments (user_id, period);
+
+-- 2) Configuración de suscripción por cliente (lista de precios) --------------
+CREATE TABLE IF NOT EXISTS subscription_config (
+    user_id     INTEGER PRIMARY KEY,             -- = usuario.id
+    amount      NUMERIC(12,2) NOT NULL DEFAULT 0,
+    active      BOOLEAN NOT NULL DEFAULT TRUE,
+    card_token  VARCHAR(255),                    -- reservado para Wompi (fase 2)
+    card_last4  VARCHAR(8),
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+-- 3) (Opcional) Tabla de anuncios / changelogs (por si aún no existe) ---------
+CREATE TABLE IF NOT EXISTS announcements (
+    id         SERIAL PRIMARY KEY,
+    message    TEXT NOT NULL DEFAULT '',
+    enabled    BOOLEAN NOT NULL DEFAULT FALSE,
+    version    INTEGER NOT NULL DEFAULT 1,
+    updated_by INTEGER,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+INSERT INTO announcements (id, message, enabled, version)
+VALUES (1, '', FALSE, 1)
+ON CONFLICT (id) DO NOTHING;

--- a/API/src/app.js
+++ b/API/src/app.js
@@ -16,6 +16,8 @@ const mailRoutes = require('./routes/mailRoutes');
 const comprasRoutes = require('./routes/comprasRoutes');
 const proveedorRoutes = require('./routes/proveedorRoutes');
 const supportChatRoutes = require('./routes/supportChatRoutes');
+const announcementRoutes = require('./routes/announcementRoutes');
+const paymentRoutes = require('./routes/paymentRoutes');
 const db = require('./db/db');
 const app = express();
 const port = 3000;
@@ -53,6 +55,8 @@ app.use('/compras', comprasRoutes);
 app.use('/proveedor', proveedorRoutes);
 app.use('/support-chat', supportChatRoutes);
 app.use('/api/support-chat', supportChatRoutes);
+app.use('/announcements', announcementRoutes);
+app.use('/payments', paymentRoutes);
 app.use('/deleted', plantillasDeleted);
 app.use('/invalidated', plantillasInvalidated);
 

--- a/API/src/controllers/announcementController.js
+++ b/API/src/controllers/announcementController.js
@@ -1,0 +1,94 @@
+const db = require('../db/db');
+
+const getRequestRole = (user = {}) => user.role ?? user.rol ?? user.id_rol ?? user.tipo_usuario ?? user.tipoUsuario ?? user.user_role ?? null;
+
+const isAdmin = (user = {}) => {
+  const role = getRequestRole(user);
+  return Number(role) === 1 || Number(user.id) === 1;
+};
+
+// Garantiza que la fila de configuración (id = 1) exista y la retorna.
+const getConfigRow = async () => {
+  let row = await db('announcements').where({ id: 1 }).first();
+  if (!row) {
+    [row] = await db('announcements')
+      .returning('*')
+      .insert({ id: 1, message: '', enabled: false, version: 1 });
+  }
+  return row;
+};
+
+// Público (autenticado): lo que ven los clientes en el home principal.
+const getCurrentAnnouncement = async (req, res) => {
+  try {
+    const row = await getConfigRow();
+    return res.status(200).json({
+      message: row.message || '',
+      enabled: Boolean(row.enabled),
+      version: Number(row.version) || 1,
+    });
+  } catch (error) {
+    console.error('Error al obtener el anuncio actual', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// Admin: obtiene la configuración completa para editarla.
+const getAnnouncement = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  try {
+    const row = await getConfigRow();
+    return res.status(200).json(row);
+  } catch (error) {
+    console.error('Error al obtener el anuncio', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// Admin: actualiza mensaje y/o toggle. Cada cambio incrementa la versión
+// para que los clientes vuelvan a ver el anuncio una sola vez.
+const updateAnnouncement = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const { message, enabled } = req.body;
+
+  try {
+    const row = await getConfigRow();
+
+    const nextMessage = message !== undefined ? String(message) : row.message;
+    const nextEnabled = enabled !== undefined ? Boolean(enabled) : Boolean(row.enabled);
+
+    // Solo se sube la versión si cambia el contenido del mensaje o se
+    // (re)activa; así un toggle off/on con el mismo texto vuelve a mostrarlo.
+    const contentChanged = nextMessage !== row.message;
+    const turnedOn = nextEnabled && !row.enabled;
+    const nextVersion = contentChanged || turnedOn ? Number(row.version) + 1 : Number(row.version);
+
+    const [updated] = await db('announcements')
+      .where({ id: 1 })
+      .update({
+        message: nextMessage,
+        enabled: nextEnabled,
+        version: nextVersion,
+        updated_by: req.user?.id || null,
+        updated_at: new Date(),
+      })
+      .returning('*');
+
+    return res.status(200).json(updated);
+  } catch (error) {
+    console.error('Error al actualizar el anuncio', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+module.exports = {
+  getCurrentAnnouncement,
+  getAnnouncement,
+  updateAnnouncement,
+};

--- a/API/src/controllers/paymentController.js
+++ b/API/src/controllers/paymentController.js
@@ -1,0 +1,539 @@
+const db = require('../db/db');
+const PDFDocument = require('pdfkit');
+
+const getRequestRole = (user = {}) => user.role ?? user.rol ?? user.id_rol ?? user.tipo_usuario ?? user.tipoUsuario ?? user.user_role ?? null;
+
+const isAdmin = (user = {}) => {
+  const role = getRequestRole(user);
+  return Number(role) === 1 || Number(user.id) === 1;
+};
+
+const canAccess = (req, userId) => isAdmin(req.user) || String(req.user?.id) === String(userId);
+
+// Reglas del ciclo de pago del servicio.
+const DUE_DAY = 15; // Todos pagan el 15 de cada mes.
+const GRACE_DAYS = 7; // 7 días de gracia -> bloqueo el día 22.
+const NOTIFY_BEFORE = 3; // Se notifica 3 días antes del vencimiento.
+const BLOCK_DAY = DUE_DAY + GRACE_DAYS;
+const PLACEHOLDER_AMOUNT = 25.0; // Monto placeholder mientras no se define por cliente.
+
+// Partes de fecha en la zona horaria de El Salvador (UTC-6), independientes
+// de la zona del servidor (Railway corre en UTC).
+const getSVDateParts = () => {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/El_Salvador',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.formatToParts(new Date()).reduce((acc, part) => {
+    acc[part.type] = part.value;
+    return acc;
+  }, {});
+
+  return {
+    year: Number(parts.year),
+    month: Number(parts.month),
+    day: Number(parts.day),
+    period: `${parts.year}-${parts.month}`,
+  };
+};
+
+const currentPeriod = () => getSVDateParts().period;
+
+// Etiqueta legible de un periodo 'YYYY-MM' -> 'julio 2026'.
+const periodLabel = (period) => {
+  const months = ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'];
+  const [year, month] = String(period || '').split('-');
+  const idx = Number(month) - 1;
+  if (idx < 0 || idx > 11) {
+    return period;
+  }
+  return `${months[idx]} ${year}`;
+};
+
+// Deriva el estado de notificación a partir de si pagó y el día del mes.
+const deriveState = (paid, dayOfMonth) => {
+  if (paid) {
+    return { state: 'al_dia', daysUntilDue: null, daysUntilBlock: null, blocked: false };
+  }
+  if (dayOfMonth < DUE_DAY - NOTIFY_BEFORE) {
+    return { state: 'al_dia', daysUntilDue: DUE_DAY - dayOfMonth, daysUntilBlock: null, blocked: false };
+  }
+  if (dayOfMonth >= DUE_DAY - NOTIFY_BEFORE && dayOfMonth < DUE_DAY) {
+    return { state: 'proximo', daysUntilDue: DUE_DAY - dayOfMonth, daysUntilBlock: null, blocked: false };
+  }
+  if (dayOfMonth === DUE_DAY) {
+    return { state: 'dia_de_pago', daysUntilDue: 0, daysUntilBlock: BLOCK_DAY - dayOfMonth, blocked: false };
+  }
+  if (dayOfMonth > DUE_DAY && dayOfMonth < BLOCK_DAY) {
+    return { state: 'pendiente', daysUntilDue: 0, daysUntilBlock: BLOCK_DAY - dayOfMonth, blocked: false };
+  }
+  return { state: 'vencido', daysUntilDue: 0, daysUntilBlock: 0, blocked: true };
+};
+
+const getSubscriptionAmount = async (userId) => {
+  const config = await db('subscription_config').where({ user_id: userId }).first();
+  if (config) {
+    return { amount: Number(config.amount), active: Boolean(config.active), configured: true };
+  }
+  return { amount: PLACEHOLDER_AMOUNT, active: true, configured: false };
+};
+
+// -------------------------------------------------------------------------
+// Estado del ciclo de pago (usado por las notificaciones).
+// -------------------------------------------------------------------------
+const getPaymentStatus = async (req, res) => {
+  const userId = req.params.userId;
+  if (!canAccess(req, userId)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  try {
+    const parts = getSVDateParts();
+    const confirmed = await db('service_payments')
+      .where({ user_id: userId, period: parts.period, status: 'confirmed' })
+      .first();
+
+    const paid = Boolean(confirmed);
+    const derived = deriveState(paid, parts.day);
+
+    return res.status(200).json({
+      period: parts.period,
+      dueDay: DUE_DAY,
+      graceDays: GRACE_DAYS,
+      blockDay: BLOCK_DAY,
+      dayOfMonth: parts.day,
+      paid,
+      ...derived,
+    });
+  } catch (error) {
+    console.error('Error al obtener el estado de pago', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// -------------------------------------------------------------------------
+// Datos de suscripción (monto del mes + estado) para la pantalla de pago.
+// -------------------------------------------------------------------------
+const getSubscription = async (req, res) => {
+  const userId = req.params.userId;
+  if (!canAccess(req, userId)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  try {
+    const period = currentPeriod();
+    const { amount, active, configured } = await getSubscriptionAmount(userId);
+
+    const periodPayment = await db('service_payments')
+      .where({ user_id: userId, period })
+      .orderBy('id', 'desc')
+      .first();
+
+    return res.status(200).json({
+      period,
+      periodLabel: periodLabel(period),
+      amount,
+      active,
+      configured,
+      dueDay: DUE_DAY,
+      currentPayment: periodPayment
+        ? {
+            id: periodPayment.id,
+            status: periodPayment.status,
+            method: periodPayment.method,
+            created_at: periodPayment.created_at,
+            confirmed_at: periodPayment.confirmed_at,
+          }
+        : null,
+    });
+  } catch (error) {
+    console.error('Error al obtener la suscripción', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// -------------------------------------------------------------------------
+// Cliente: enviar comprobante de transferencia.
+// -------------------------------------------------------------------------
+const submitTransfer = async (req, res) => {
+  const userId = req.params.userId;
+  if (!canAccess(req, userId)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const { proof, proof_mime, proof_name, reference, note } = req.body;
+
+  if (!proof || !String(proof).trim()) {
+    return res.status(400).json({ message: 'El comprobante es obligatorio' });
+  }
+
+  try {
+    const period = currentPeriod();
+    const { amount } = await getSubscriptionAmount(userId);
+
+    const existing = await db('service_payments')
+      .where({ user_id: userId, period })
+      .orderBy('id', 'desc')
+      .first();
+
+    if (existing && existing.status === 'confirmed') {
+      return res.status(409).json({ message: 'El pago de este mes ya fue confirmado.' });
+    }
+
+    const payload = {
+      user_id: userId,
+      period,
+      status: 'pending',
+      method: 'transfer',
+      amount,
+      reference: reference ? String(reference).trim() : null,
+      proof: String(proof),
+      proof_mime: proof_mime || null,
+      proof_name: proof_name || null,
+      note: note ? String(note).trim() : null,
+      reviewed_by: null,
+      confirmed_at: null,
+      updated_at: new Date(),
+    };
+
+    let result;
+    if (existing) {
+      [result] = await db('service_payments').where({ id: existing.id }).update(payload).returning('*');
+    } else {
+      [result] = await db('service_payments').insert(payload).returning('*');
+    }
+
+    // No devolver el base64 del comprobante en la respuesta.
+    delete result.proof;
+    return res.status(201).json(result);
+  } catch (error) {
+    console.error('Error al enviar el comprobante', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// -------------------------------------------------------------------------
+// Historial de pagos del cliente (para descargar tickets).
+// -------------------------------------------------------------------------
+const getMyPayments = async (req, res) => {
+  const userId = req.params.userId;
+  if (!canAccess(req, userId)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  try {
+    const rows = await db('service_payments')
+      .where({ user_id: userId })
+      .orderBy('period', 'desc')
+      .orderBy('id', 'desc');
+
+    const payments = rows.map((row) => ({
+      id: row.id,
+      period: row.period,
+      periodLabel: periodLabel(row.period),
+      status: row.status,
+      method: row.method,
+      amount: Number(row.amount || 0),
+      reference: row.reference,
+      has_proof: Boolean(row.proof),
+      proof_mime: row.proof_mime,
+      created_at: row.created_at,
+      confirmed_at: row.confirmed_at,
+    }));
+
+    return res.status(200).json(payments);
+  } catch (error) {
+    console.error('Error al obtener el historial de pagos', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// -------------------------------------------------------------------------
+// Comprobante subido (imagen/PDF) - dueño o admin.
+// -------------------------------------------------------------------------
+const getProof = async (req, res) => {
+  const paymentId = req.params.paymentId;
+
+  try {
+    const payment = await db('service_payments').where({ id: paymentId }).first();
+    if (!payment) {
+      return res.status(404).json({ message: 'Pago no encontrado' });
+    }
+    if (!canAccess(req, payment.user_id)) {
+      return res.status(403).json({ message: 'No autorizado' });
+    }
+    if (!payment.proof) {
+      return res.status(404).json({ message: 'Sin comprobante' });
+    }
+
+    return res.status(200).json({
+      id: payment.id,
+      proof: payment.proof,
+      proof_mime: payment.proof_mime,
+      proof_name: payment.proof_name,
+    });
+  } catch (error) {
+    console.error('Error al obtener el comprobante', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// -------------------------------------------------------------------------
+// Ticket PDF (no válido como documento fiscal) - dueño o admin.
+// -------------------------------------------------------------------------
+const getTicket = async (req, res) => {
+  const paymentId = req.params.paymentId;
+
+  try {
+    const payment = await db('service_payments').where({ id: paymentId }).first();
+    if (!payment) {
+      return res.status(404).json({ message: 'Pago no encontrado' });
+    }
+    if (!canAccess(req, payment.user_id)) {
+      return res.status(403).json({ message: 'No autorizado' });
+    }
+    if (payment.status !== 'confirmed') {
+      return res.status(400).json({ message: 'El ticket solo está disponible para pagos confirmados.' });
+    }
+
+    const userDB = await db('usuario')
+      .leftJoin('emisor', 'usuario.id', 'emisor.id_usuario')
+      .where('usuario.id', payment.user_id)
+      .first();
+    const clientName = (userDB && (userDB.name || userDB.usuario)) || `Usuario #${payment.user_id}`;
+
+    const doc = new PDFDocument({ size: 'A4', margins: { top: 50, bottom: 50, left: 50, right: 50 } });
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', `inline; filename="ticket-${payment.period}.pdf"`);
+    doc.pipe(res);
+
+    const brand = '#1E3256';
+    const money = (v) => `$${Number(v || 0).toFixed(2)}`;
+
+    // Encabezado
+    doc.rect(0, 0, doc.page.width, 110).fill(brand);
+    doc.fillColor('#FFFFFF').fontSize(20).text('Comprobante de Pago de Servicio', 50, 40);
+    doc.fontSize(10).fillColor('#D6DEEC').text('Documento informativo - no válido como comprobante fiscal (DTE/CFE)', 50, 70);
+
+    doc.fillColor('#000000');
+    let y = 150;
+    const line = (label, value) => {
+      doc.fontSize(11).fillColor('#6B7280').text(label, 50, y);
+      doc.fontSize(13).fillColor('#111827').text(String(value), 50, y + 15);
+      y += 48;
+    };
+
+    line('Ticket N.º', String(payment.id).padStart(6, '0'));
+    line('Cliente', clientName);
+    line('Periodo', periodLabel(payment.period));
+    line('Método', payment.method === 'card' ? 'Tarjeta' : 'Transferencia bancaria');
+    if (payment.reference) {
+      line('Referencia', payment.reference);
+    }
+    line('Fecha de confirmación', payment.confirmed_at ? new Date(payment.confirmed_at).toLocaleString('es-ES') : '-');
+
+    // Total destacado
+    y += 10;
+    doc.rect(50, y, doc.page.width - 100, 60).fill('#F1F5F9');
+    doc.fillColor('#6B7280').fontSize(12).text('Monto pagado', 70, y + 12);
+    doc.fillColor(brand).fontSize(26).text(money(payment.amount), 70, y + 26);
+
+    doc.fillColor('#9CA3AF').fontSize(9).text('Generado automáticamente por el sistema.', 50, doc.page.height - 70, {
+      align: 'center',
+      width: doc.page.width - 100,
+    });
+
+    doc.end();
+  } catch (error) {
+    console.error('Error al generar el ticket', error);
+    if (!res.headersSent) {
+      return res.status(500).json({ message: 'Error en el servidor' });
+    }
+  }
+};
+
+// -------------------------------------------------------------------------
+// ADMIN
+// -------------------------------------------------------------------------
+
+// Lista de clientes con su monto y el estado del periodo indicado.
+const adminListClients = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const period = req.query.period || currentPeriod();
+
+  try {
+    const users = await db('usuario as u')
+      .leftJoin('emisor as e', 'e.id_usuario', 'u.id')
+      .leftJoin('subscription_config as sc', 'sc.user_id', 'u.id')
+      .select(
+        'u.id as user_id',
+        'u.usuario as username',
+        'e.name as name',
+        'sc.amount as amount',
+        'sc.active as active'
+      );
+
+    const payments = await db('service_payments').where({ period }).orderBy('id', 'desc');
+    const paymentByUser = {};
+    payments.forEach((p) => {
+      if (!paymentByUser[p.user_id]) {
+        paymentByUser[p.user_id] = p;
+      }
+    });
+
+    const clients = users.map((u) => {
+      const p = paymentByUser[u.user_id];
+      return {
+        user_id: u.user_id,
+        username: u.username,
+        name: u.name || u.username,
+        amount: u.amount != null ? Number(u.amount) : PLACEHOLDER_AMOUNT,
+        configured: u.amount != null,
+        active: u.active == null ? true : Boolean(u.active),
+        payment: p
+          ? {
+              id: p.id,
+              status: p.status,
+              method: p.method,
+              has_proof: Boolean(p.proof),
+              created_at: p.created_at,
+              confirmed_at: p.confirmed_at,
+            }
+          : null,
+        period_status: p ? p.status : 'none',
+      };
+    });
+
+    return res.status(200).json({ period, periodLabel: periodLabel(period), clients });
+  } catch (error) {
+    console.error('Error al listar clientes', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// Historial de pagos de un cliente (admin).
+const adminGetUserPayments = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const userId = req.params.userId;
+
+  try {
+    const rows = await db('service_payments')
+      .where({ user_id: userId })
+      .orderBy('period', 'desc')
+      .orderBy('id', 'desc');
+
+    const payments = rows.map((row) => ({
+      id: row.id,
+      period: row.period,
+      periodLabel: periodLabel(row.period),
+      status: row.status,
+      method: row.method,
+      amount: Number(row.amount || 0),
+      reference: row.reference,
+      note: row.note,
+      has_proof: Boolean(row.proof),
+      proof_mime: row.proof_mime,
+      created_at: row.created_at,
+      confirmed_at: row.confirmed_at,
+    }));
+
+    return res.status(200).json(payments);
+  } catch (error) {
+    console.error('Error al obtener pagos del cliente', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// Confirmar o rechazar un pago.
+const adminReviewPayment = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const paymentId = req.params.paymentId;
+  const { action, note } = req.body;
+
+  if (!['confirm', 'reject'].includes(action)) {
+    return res.status(400).json({ message: 'Acción inválida' });
+  }
+
+  try {
+    const payment = await db('service_payments').where({ id: paymentId }).first();
+    if (!payment) {
+      return res.status(404).json({ message: 'Pago no encontrado' });
+    }
+
+    const update = {
+      status: action === 'confirm' ? 'confirmed' : 'rejected',
+      reviewed_by: req.user?.id || null,
+      confirmed_at: action === 'confirm' ? new Date() : null,
+      note: note ? String(note).trim() : payment.note,
+      updated_at: new Date(),
+    };
+
+    const [updated] = await db('service_payments').where({ id: paymentId }).update(update).returning('*');
+    delete updated.proof;
+    return res.status(200).json(updated);
+  } catch (error) {
+    console.error('Error al revisar el pago', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// Editar el monto de suscripción de un cliente (lista de precios).
+const adminSetAmount = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const userId = req.params.userId;
+  const { amount, active } = req.body;
+
+  if (amount == null || Number.isNaN(Number(amount)) || Number(amount) < 0) {
+    return res.status(400).json({ message: 'Monto inválido' });
+  }
+
+  try {
+    const existing = await db('subscription_config').where({ user_id: userId }).first();
+    const payload = {
+      amount: Number(amount),
+      active: active == null ? true : Boolean(active),
+      updated_at: new Date(),
+    };
+
+    let result;
+    if (existing) {
+      [result] = await db('subscription_config').where({ user_id: userId }).update(payload).returning('*');
+    } else {
+      [result] = await db('subscription_config')
+        .insert({ user_id: userId, ...payload })
+        .returning('*');
+    }
+
+    return res.status(200).json(result);
+  } catch (error) {
+    console.error('Error al actualizar el monto', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+module.exports = {
+  getPaymentStatus,
+  getSubscription,
+  submitTransfer,
+  getMyPayments,
+  getProof,
+  getTicket,
+  adminListClients,
+  adminGetUserPayments,
+  adminReviewPayment,
+  adminSetAmount,
+};

--- a/API/src/routes/announcementRoutes.js
+++ b/API/src/routes/announcementRoutes.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  getCurrentAnnouncement,
+  getAnnouncement,
+  updateAnnouncement,
+} = require('../controllers/announcementController');
+const authenticateToken = require('../middleware/verifyToken.js');
+
+router.get('/current', authenticateToken, getCurrentAnnouncement);
+router.get('/', authenticateToken, getAnnouncement);
+router.put('/', authenticateToken, updateAnnouncement);
+
+module.exports = router;

--- a/API/src/routes/paymentRoutes.js
+++ b/API/src/routes/paymentRoutes.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const router = express.Router();
+
+const {
+  getPaymentStatus,
+  getSubscription,
+  submitTransfer,
+  getMyPayments,
+  getProof,
+  getTicket,
+  adminListClients,
+  adminGetUserPayments,
+  adminReviewPayment,
+  adminSetAmount,
+} = require('../controllers/paymentController');
+const authenticateToken = require('../middleware/verifyToken.js');
+
+// Cliente
+router.get('/status/:userId', authenticateToken, getPaymentStatus);
+router.get('/subscription/:userId', authenticateToken, getSubscription);
+router.post('/transfer/:userId', authenticateToken, submitTransfer);
+router.get('/mine/:userId', authenticateToken, getMyPayments);
+
+// Comprobante / ticket (dueño o admin)
+router.get('/proof/:paymentId', authenticateToken, getProof);
+router.get('/ticket/:paymentId', authenticateToken, getTicket);
+
+// Admin
+router.get('/admin/clients', authenticateToken, adminListClients);
+router.get('/admin/user/:userId', authenticateToken, adminGetUserPayments);
+router.put('/admin/review/:paymentId', authenticateToken, adminReviewPayment);
+router.put('/admin/amount/:userId', authenticateToken, adminSetAmount);
+
+module.exports = router;

--- a/dte-web-app/src/App.jsx
+++ b/dte-web-app/src/App.jsx
@@ -35,6 +35,9 @@ import CreateCR from './pages/CreateCR';
 import CreateCI from './pages/CreateCI';
 import DownloadDTEs from './pages/DownloadDTEs';
 import SupportChat from './pages/SupportChat';
+import AnnouncementAdmin from './pages/AnnouncementAdmin';
+import PagoServicio from './pages/PagoServicio';
+import PaymentsAdmin from './pages/PaymentsAdmin';
 
 /* http://localhost:3000/#/ingresar the example route */
 export default function App() {
@@ -91,6 +94,9 @@ export default function App() {
         <Route path="/perfil" element={<Private><Profile/></Private>}/>
         <Route path="/soporte" element={<Private><SupportChat mode="user" /></Private>}/>
         <Route path="/testadmin/support-chat" element={<Private><SupportChat mode="admin" /></Private>}/>
+        <Route path="/testadmin/changelog" element={<Private><AnnouncementAdmin /></Private>}/>
+        <Route path="/pago" element={<Private><PagoServicio /></Private>}/>
+        <Route path="/testadmin/pagos" element={<Private><PaymentsAdmin /></Private>}/>
 
         <Route path="/sidebar" element={<Private><Sidebar/></Private>}/>
 

--- a/dte-web-app/src/components/SideBarComponent.jsx
+++ b/dte-web-app/src/components/SideBarComponent.jsx
@@ -18,10 +18,13 @@ const GroupComponent = ({ visible, setVisible }) => {
   const GoDownloadDTEs = () => navigate("/descargar-dtes");
   const GoSupportChat = () => navigate(isSupportAdmin ? "/testadmin/support-chat" : "/soporte");
   const GoSupportAdmin = () => navigate("/testadmin/support-chat");
+  const GoPagoServicio = () => navigate("/pago");
+  const GoPagosAdmin = () => navigate("/testadmin/pagos");
   const CloseHandler = () => navigate("/ingresar");
   const currentUserId = Number(localStorage.getItem('user_id'));
   const currentUserRole = Number(localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol'));
   const isSupportAdmin = currentUserId === 1 || currentUserRole === 1;
+  const isMainAdmin = currentUserId === 1;
 
   return (
     <>
@@ -92,12 +95,28 @@ const GroupComponent = ({ visible, setVisible }) => {
             <span className="text-sm text-gray-800 group-hover:text-sky-700">Descargar DTEs</span>
           </button>
 
+          <button onClick={GoPagoServicio} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
+            <svg className="h-6 w-6 text-gray-600 group-hover:text-sky-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
+            </svg>
+            <span className="text-sm text-gray-800 group-hover:text-sky-700">Pago de servicio</span>
+          </button>
+
           <button onClick={GoSupportChat} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
             <svg className="h-6 w-6 text-gray-600 group-hover:text-sky-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h8m-8 4h5m1 5l-3 3-3-3h-2a4 4 0 01-4-4V6a4 4 0 014-4h12a4 4 0 014 4v8a4 4 0 01-4 4h-3z" />
             </svg>
             <span className="text-sm text-gray-800 group-hover:text-sky-700">Soporte / Chat</span>
           </button>
+
+          {isMainAdmin && (
+            <button onClick={GoPagosAdmin} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-blue-50 transition group border border-blue-100 bg-blue-50/60">
+              <svg className="h-6 w-6 text-steelblue-300 group-hover:text-steelblue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 7h6m-6 4h6m-6 4h4M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z" />
+              </svg>
+              <span className="text-sm text-gray-800 group-hover:text-steelblue-300 font-semibold">Pagos (admin)</span>
+            </button>
+          )}
 
           {isSupportAdmin && (
             <button onClick={GoSupportAdmin} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-blue-50 transition group border border-blue-100 bg-blue-50/60">

--- a/dte-web-app/src/pages/AnnouncementAdmin.jsx
+++ b/dte-web-app/src/pages/AnnouncementAdmin.jsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import AnnouncementService from '../services/AnnouncementService';
+
+const AnnouncementAdmin = () => {
+  const token = localStorage.getItem('token');
+  const currentUserId = Number(localStorage.getItem('user_id'));
+  const currentUserRole = Number(localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol'));
+  const isAdmin = currentUserId === 1 || currentUserRole === 1;
+  const navigate = useNavigate();
+
+  const [message, setMessage] = useState('');
+  const [enabled, setEnabled] = useState(false);
+  const [version, setVersion] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isAdmin) {
+      navigate('/principal');
+      return;
+    }
+
+    const fetchConfig = async () => {
+      try {
+        const data = await AnnouncementService.getAdmin(token);
+        setMessage(data.message || '');
+        setEnabled(Boolean(data.enabled));
+        setVersion(Number(data.version) || 1);
+      } catch (error) {
+        console.error('Error al cargar el anuncio', error);
+        toast.error('No se pudo cargar la configuración');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchConfig();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleSave = async () => {
+    if (!message.trim()) {
+      toast.info('Escribe un mensaje antes de guardar');
+      return;
+    }
+    setSaving(true);
+    try {
+      const updated = await AnnouncementService.update(token, { message: message.trim(), enabled });
+      setMessage(updated.message || '');
+      setEnabled(Boolean(updated.enabled));
+      setVersion(Number(updated.version) || version);
+      toast.success('Anuncio actualizado');
+    } catch (error) {
+      console.error('Error al guardar el anuncio', error);
+      toast.error('No se pudo guardar el anuncio');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-steelblue-300 px-3 py-6 sm:px-6 sm:py-10 animate-fadeIn">
+      <div className="mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-white/20 bg-white shadow-2xl">
+        {/* Header */}
+        <header className="flex items-center justify-between gap-3 border-b border-gray-100 bg-steelblue-300 px-4 py-3 sm:px-6 sm:py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/25 sm:h-11 sm:w-11">
+              <svg className="h-5 w-5 text-white sm:h-6 sm:w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+              </svg>
+            </div>
+            <div className="min-w-0">
+              <h1 className="truncate text-base font-semibold leading-tight text-white sm:text-lg">Anuncio / Changelogs</h1>
+              <p className="truncate text-xs text-white/80">Mensaje del menú principal</p>
+            </div>
+          </div>
+          <button
+            onClick={() => navigate('/principal')}
+            className="shrink-0 rounded-full border border-white/25 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/25 sm:px-4 sm:py-2 sm:text-sm"
+          >
+            Volver
+          </button>
+        </header>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <div className="h-9 w-9 animate-spin rounded-full border-4 border-steelblue-200 border-t-transparent" />
+          </div>
+        ) : (
+          <div className="space-y-5 p-4 sm:p-6">
+            <p className="rounded-xl bg-slate-50 px-4 py-3 text-sm leading-relaxed text-slate-600">
+              Este mensaje aparece <span className="font-medium text-slate-800">una sola vez</span> a cada cliente en el menú principal.
+              Al cambiar el texto o volver a activarlo, todos los clientes lo verán nuevamente.
+            </p>
+
+            {/* Toggle */}
+            <div className="flex items-center justify-between rounded-xl border border-gray-100 px-4 py-3">
+              <div>
+                <p className="text-sm font-semibold text-slate-900">Mostrar anuncio</p>
+                <p className={`text-xs font-medium ${enabled ? 'text-emerald-600' : 'text-slate-400'}`}>
+                  {enabled ? 'Activado' : 'Desactivado'}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setEnabled((prev) => !prev)}
+                className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors duration-300 ${
+                  enabled ? 'bg-emerald-500' : 'bg-gray-300'
+                }`}
+                aria-pressed={enabled}
+              >
+                <span
+                  className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform duration-300 ${
+                    enabled ? 'translate-x-6' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
+
+            {/* Mensaje */}
+            <div>
+              <label className="mb-2 block text-sm font-semibold text-slate-900">Mensaje</label>
+              <textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                rows={6}
+                maxLength={2000}
+                placeholder="Escribe las novedades / actualizaciones para los clientes..."
+                className="w-full resize-none rounded-xl border border-gray-200 bg-white p-3 text-sm text-slate-800 placeholder:text-slate-400 outline-none transition focus:border-steelblue-200 focus:ring-2 focus:ring-steelblue-100"
+              />
+              <div className="mt-1 flex items-center justify-between text-xs text-slate-400">
+                <span>Versión actual: {version}</span>
+                <span>{message.length}/2000</span>
+              </div>
+            </div>
+
+            {/* Vista previa */}
+            {message.trim() && (
+              <div className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+                <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Vista previa</p>
+                <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-slate-800">{message}</p>
+              </div>
+            )}
+
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-steelblue-300 py-3 font-semibold text-white shadow-lg shadow-steelblue-300/20 transition hover:bg-steelblue-200 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {saving && <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />}
+              {saving ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      <ToastContainer position="top-center" autoClose={3000} theme="light" />
+    </div>
+  );
+};
+
+export default AnnouncementAdmin;

--- a/dte-web-app/src/pages/Home.jsx
+++ b/dte-web-app/src/pages/Home.jsx
@@ -1,22 +1,54 @@
-import Homeimg from '../assets/imgs/homeimg.webp'         
-import { useState } from 'react';
+import Homeimg from '../assets/imgs/homeimg.webp'
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import hamburgerimg from '../assets/imgs/hamburguerimg.png'
 import SidebarComponent from '../components/SideBarComponent';
 import HamburguerComponent from '../components/HamburguerComponent';
+import AnnouncementService from '../services/AnnouncementService';
 
 import list from '../assets/imgs/portapapeles.png';
 
 const Home = () => {
   const [visible, setVisible] = useState(false);
   const navigate = useNavigate();
+  const token = localStorage.getItem("token");
   const username = localStorage.getItem("username");
   const ambiente = localStorage.getItem("ambiente");
   const userNumber = localStorage.getItem("userNumber");
   const currentUserId = Number(localStorage.getItem('user_id'));
   const currentUserRole = Number(localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol'));
   const isSupportAdmin = currentUserId === 1 || currentUserRole === 1;
-  
+
+  // Anuncio / changelogs: se muestra una sola vez por versión a cada cliente.
+  const [announcement, setAnnouncement] = useState(null);
+  const [showAnnouncement, setShowAnnouncement] = useState(false);
+
+  useEffect(() => {
+    const fetchAnnouncement = async () => {
+      try {
+        const data = await AnnouncementService.getCurrent(token);
+        if (data && data.enabled && data.message && String(data.message).trim()) {
+          const seenVersion = Number(localStorage.getItem('announcement_seen_version') || 0);
+          if (Number(data.version) !== seenVersion) {
+            setAnnouncement(data);
+            setShowAnnouncement(true);
+          }
+        }
+      } catch (error) {
+        console.error('Error al obtener el anuncio', error);
+      }
+    };
+
+    fetchAnnouncement();
+  }, [token]);
+
+  const closeAnnouncement = () => {
+    if (announcement) {
+      localStorage.setItem('announcement_seen_version', String(announcement.version));
+    }
+    setShowAnnouncement(false);
+  };
+
   const getAmbienteText = (ambienteValue) => {
     if (ambienteValue === "01") return "PRODUCCIÓN";
     if (ambienteValue === "00") return "PRUEBAS";
@@ -25,6 +57,10 @@ const Home = () => {
 
   const SupportHandler = () => {
     navigate(isSupportAdmin ? "/testadmin/support-chat" : "/soporte");
+  }
+
+  const ChangelogAdminHandler = () => {
+    navigate("/testadmin/changelog");
   }
 
   const CreateBillHandler = () => {
@@ -37,6 +73,33 @@ const Home = () => {
 
   return (
     <div className="w-full min-h-screen bg-steelblue-300 flex flex-col items-center justify-center relative animate-fadeIn">
+      {/* Modal de anuncio / changelogs */}
+      {showAnnouncement && announcement && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fadeIn">
+          <div className="bg-white w-full max-w-md rounded-2xl shadow-2xl ring-1 ring-black/5 overflow-hidden animate-fadeInUp">
+            <div className="bg-steelblue-300 px-6 py-4 flex items-center gap-3">
+              <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+              </svg>
+              <h2 className="text-lg font-bold text-white">Novedades y actualizaciones</h2>
+            </div>
+            <div className="px-6 py-5 max-h-[50vh] overflow-y-auto">
+              <p className="text-sm text-gray-800 whitespace-pre-wrap leading-relaxed">
+                {announcement.message}
+              </p>
+            </div>
+            <div className="px-6 pb-5">
+              <button
+                onClick={closeAnnouncement}
+                className="w-full bg-steelblue-300 hover:bg-steelblue-200 text-white font-semibold py-2.5 rounded-xl transition"
+              >
+                Entendido
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Hamburguer y Sidebar fuera del flujo principal */}
       <div className="absolute top-0 left-0 z-20 animate-slideInLeft">
   <HamburguerComponent sidebar={sidebar} open={visible} />
@@ -150,6 +213,20 @@ const Home = () => {
               {isSupportAdmin ? 'Panel de soporte' : 'Soporte / Chat'}
             </span>
           </button>
+
+          {isSupportAdmin && (
+            <button
+              className="w-full flex flex-row items-center bg-white rounded-xl shadow-lg px-6 py-4 hover:scale-105 hover:shadow-2xl hover:bg-amber-50 active:scale-95 transition-all duration-300 group border border-amber-100"
+              onClick={ChangelogAdminHandler}
+            >
+              <svg className="h-10 w-10 mr-4 text-steelblue-300 transition-transform duration-300 group-hover:rotate-12 group-hover:scale-110" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z" />
+              </svg>
+              <span className="text-xl font-inter text-black transition-all duration-300 group-hover:text-amber-600 group-hover:font-semibold">
+                Anuncio / Changelogs
+              </span>
+            </button>
+          )}
         </div>
 
         {/* Footer */}

--- a/dte-web-app/src/pages/HomeFacturas.jsx
+++ b/dte-web-app/src/pages/HomeFacturas.jsx
@@ -5,6 +5,7 @@ import HamburguerComponent from "../components/HamburguerComponent";
 import SidebarComponent from "../components/SideBarComponent";
 import PlantillaAPI from "../services/PlantillaService";
 import UserService from "../services/UserServices";
+import PaymentService from "../services/PaymentService";
 import { useNavigate } from "react-router-dom";
 import LoginAPI from "../services/Loginservices";
 import * as XLSX from "xlsx";
@@ -14,6 +15,37 @@ import FilterModal from "../components/FilterModal";
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import ExcelJS from 'exceljs';
+
+// Construye el mensaje y tipo de toast según el estado del ciclo de pago.
+const buildPaymentNotice = (status) => {
+  if (!status || !status.state) {
+    return null;
+  }
+
+  switch (status.state) {
+    case 'al_dia':
+      return { type: 'success', message: 'Su cuenta está al día. ¡Gracias!' };
+    case 'proximo':
+      return {
+        type: 'info',
+        message: `Su pago es en ${status.daysUntilDue} día${status.daysUntilDue === 1 ? '' : 's'} (vence el 15).`,
+      };
+    case 'dia_de_pago':
+      return { type: 'warning', message: 'Hoy es el día de pago de su usuario.' };
+    case 'pendiente':
+      return {
+        type: 'error',
+        message: `Su usuario tiene pendiente el pago del servicio. En ${status.daysUntilBlock} día${status.daysUntilBlock === 1 ? '' : 's'} se bloqueará la cuenta hasta la confirmación del pago.`,
+      };
+    case 'vencido':
+      return {
+        type: 'error',
+        message: 'Su cuenta está pendiente de pago. Realice el pago para reactivar el servicio.',
+      };
+    default:
+      return null;
+  }
+};
 
 const HomeFacturas = () => {
   const token = localStorage.getItem("token");
@@ -128,6 +160,30 @@ const HomeFacturas = () => {
                 navigate("/ingresar");
             }
         setUser(resultusers);
+
+        // Notificación del ciclo de pago: solo la primera vez que se entra
+        // a la pantalla en esta sesión.
+        try {
+          const noticeKey = `payment_notice_shown_${user_id}`;
+          if (!sessionStorage.getItem(noticeKey)) {
+            const status = await PaymentService.getStatus(user_id, token);
+            const notice = buildPaymentNotice(status);
+            if (notice) {
+              const toastFn = toast[notice.type] || toast.info;
+              toastFn(notice.message, {
+                position: "top-center",
+                autoClose: notice.type === 'error' ? 8000 : 5000,
+                closeOnClick: true,
+                draggable: true,
+                style: { zIndex: 200000 },
+              });
+            }
+            sessionStorage.setItem(noticeKey, '1');
+          }
+        } catch (paymentError) {
+          console.error("Error al obtener el estado de pago:", paymentError);
+        }
+
           await loadBillsPage({ page: 1, reset: true });
 
         if (tokenminis === "undefined" || tokenminis === null) {

--- a/dte-web-app/src/pages/PagoServicio.jsx
+++ b/dte-web-app/src/pages/PagoServicio.jsx
@@ -1,0 +1,378 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import PaymentService from '../services/PaymentService';
+
+// Cuentas bancarias placeholder (editar cuando estén las reales).
+const BANK_ACCOUNTS = [
+  {
+    bank: 'Banco Agrícola',
+    type: 'Cuenta Corriente',
+    number: '0000-0000-0000',
+    holder: 'MySoftware SV, S.A. de C.V.',
+    doc: 'NIT 0000-000000-000-0',
+  },
+  {
+    bank: 'Banco Cuscatlán',
+    type: 'Cuenta de Ahorro',
+    number: '1111-1111-1111',
+    holder: 'MySoftware SV, S.A. de C.V.',
+    doc: 'NIT 0000-000000-000-0',
+  },
+];
+
+const MAX_PROOF_MB = 8;
+
+const statusMeta = (status) => {
+  switch (status) {
+    case 'confirmed':
+      return { label: 'Confirmado', cls: 'bg-emerald-100 text-emerald-700' };
+    case 'pending':
+      return { label: 'En revisión', cls: 'bg-amber-100 text-amber-700' };
+    case 'rejected':
+      return { label: 'Rechazado', cls: 'bg-red-100 text-red-700' };
+    default:
+      return { label: 'Sin pago', cls: 'bg-slate-100 text-slate-500' };
+  }
+};
+
+const money = (v) => `$${Number(v || 0).toFixed(2)}`;
+
+const PagoServicio = () => {
+  const token = localStorage.getItem('token');
+  const userId = localStorage.getItem('user_id');
+  const navigate = useNavigate();
+
+  const [tab, setTab] = useState('transfer'); // transfer | card | history
+  const [sub, setSub] = useState(null);
+  const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const [proof, setProof] = useState(null); // { dataUrl, mime, name, isImage }
+  const [reference, setReference] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [downloadingId, setDownloadingId] = useState(null);
+  const fileInputRef = useRef(null);
+
+  const loadData = async () => {
+    try {
+      const [subscription, mine] = await Promise.all([
+        PaymentService.getSubscription(userId, token),
+        PaymentService.getMyPayments(userId, token),
+      ]);
+      setSub(subscription);
+      setHistory(Array.isArray(mine) ? mine : []);
+    } catch (error) {
+      console.error('Error al cargar el pago', error);
+      toast.error('No se pudo cargar la información de pago');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!token || !userId) {
+      navigate('/ingresar');
+      return;
+    }
+    loadData();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleFile = (event) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+    if (!file) {
+      return;
+    }
+    const isImage = file.type.startsWith('image/');
+    const isPdf = file.type === 'application/pdf';
+    if (!isImage && !isPdf) {
+      toast.info('Solo se permiten imágenes o PDF.');
+      return;
+    }
+    if (file.size > MAX_PROOF_MB * 1024 * 1024) {
+      toast.info(`El archivo supera los ${MAX_PROOF_MB} MB.`);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setProof({ dataUrl: String(reader.result || ''), mime: file.type, name: file.name, isImage });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const copyToClipboard = async (value) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast.success('Copiado');
+    } catch {
+      toast.info('No se pudo copiar');
+    }
+  };
+
+  const handleSubmitTransfer = async () => {
+    if (!proof) {
+      toast.info('Adjunta el comprobante de la transferencia.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await PaymentService.submitTransfer(userId, token, {
+        proof: proof.dataUrl,
+        proof_mime: proof.mime,
+        proof_name: proof.name,
+        reference: reference.trim(),
+      });
+      toast.success('Comprobante enviado. Soporte lo validará pronto.');
+      setProof(null);
+      setReference('');
+      await loadData();
+    } catch (error) {
+      console.error('Error al enviar el comprobante', error);
+      toast.error(error?.message || 'No se pudo enviar el comprobante');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDownloadTicket = async (paymentId) => {
+    setDownloadingId(paymentId);
+    try {
+      const url = await PaymentService.getTicketBlobUrl(paymentId, token);
+      window.open(url, '_blank', 'noopener');
+      setTimeout(() => window.URL.revokeObjectURL(url), 60000);
+    } catch (error) {
+      console.error('Error al descargar el ticket', error);
+      toast.error(error?.message || 'No se pudo descargar el ticket');
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  const current = sub?.currentPayment;
+  const currentMeta = statusMeta(current?.status);
+  const alreadyPaid = current?.status === 'confirmed';
+
+  const TabButton = ({ id, label }) => (
+    <button
+      onClick={() => setTab(id)}
+      className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition ${
+        tab === id ? 'bg-white text-steelblue-300 shadow-sm' : 'text-white/80 hover:text-white'
+      }`}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="min-h-screen bg-steelblue-300 px-3 py-6 sm:px-6 sm:py-10 animate-fadeIn">
+      <div className="mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-white/20 bg-white shadow-2xl">
+        {/* Header */}
+        <header className="flex items-center justify-between gap-3 border-b border-gray-100 bg-steelblue-300 px-4 py-3 sm:px-6 sm:py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/25 sm:h-11 sm:w-11">
+              <svg className="h-5 w-5 text-white sm:h-6 sm:w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+              </svg>
+            </div>
+            <div className="min-w-0">
+              <h1 className="truncate text-base font-semibold leading-tight text-white sm:text-lg">Pago de servicio</h1>
+              <p className="truncate text-xs text-white/80">{sub ? `Periodo ${sub.periodLabel}` : 'Cargando...'}</p>
+            </div>
+          </div>
+          <button
+            onClick={() => navigate('/principal')}
+            className="shrink-0 rounded-full border border-white/25 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/25 sm:px-4 sm:py-2 sm:text-sm"
+          >
+            Volver
+          </button>
+        </header>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <div className="h-9 w-9 animate-spin rounded-full border-4 border-steelblue-200 border-t-transparent" />
+          </div>
+        ) : (
+          <div className="p-4 sm:p-6">
+            {/* Resumen del monto */}
+            <div className="mb-5 flex items-center justify-between rounded-2xl bg-slate-50 px-5 py-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.18em] text-slate-400">Monto del mes</p>
+                <p className="mt-1 text-3xl font-bold text-steelblue-300">{money(sub?.amount)}</p>
+                <p className="mt-1 text-xs text-slate-500">Vence el {sub?.dueDay} de {sub?.periodLabel}</p>
+              </div>
+              <span className={`rounded-full px-3 py-1 text-xs font-semibold ${currentMeta.cls}`}>{currentMeta.label}</span>
+            </div>
+
+            {/* Tabs */}
+            <div className="mb-5 flex gap-1 rounded-xl bg-steelblue-300 p-1">
+              <TabButton id="transfer" label="Transferencia" />
+              <TabButton id="card" label="Tarjeta" />
+              <TabButton id="history" label="Historial" />
+            </div>
+
+            {/* --- Transferencia --- */}
+            {tab === 'transfer' && (
+              <div className="space-y-4">
+                {alreadyPaid ? (
+                  <div className="rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+                    El pago de {sub.periodLabel} ya fue confirmado. ¡Gracias!
+                  </div>
+                ) : current?.status === 'pending' ? (
+                  <div className="rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+                    Ya enviaste un comprobante este mes. Está en revisión; puedes reemplazarlo abajo si lo necesitas.
+                  </div>
+                ) : null}
+
+                <div>
+                  <p className="mb-2 text-sm font-semibold text-slate-900">1. Transfiere a una de estas cuentas</p>
+                  <div className="space-y-3">
+                    {BANK_ACCOUNTS.map((acc) => (
+                      <div key={acc.number} className="rounded-xl border border-gray-100 p-4">
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm font-semibold text-slate-900">{acc.bank}</p>
+                          <span className="text-xs text-slate-400">{acc.type}</span>
+                        </div>
+                        <div className="mt-2 flex items-center justify-between gap-3">
+                          <span className="font-mono text-base tracking-wide text-slate-800">{acc.number}</span>
+                          <button
+                            onClick={() => copyToClipboard(acc.number)}
+                            className="shrink-0 rounded-lg border border-gray-200 px-2.5 py-1 text-xs font-medium text-slate-600 transition hover:bg-slate-50"
+                          >
+                            Copiar
+                          </button>
+                        </div>
+                        <p className="mt-1 text-xs text-slate-500">{acc.holder}</p>
+                        <p className="text-xs text-slate-400">{acc.doc}</p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                <div>
+                  <p className="mb-2 text-sm font-semibold text-slate-900">2. Sube el comprobante</p>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*,application/pdf"
+                    className="hidden"
+                    onChange={handleFile}
+                  />
+                  {!proof ? (
+                    <button
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex w-full flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-200 py-8 text-slate-500 transition hover:border-steelblue-200 hover:bg-slate-50"
+                    >
+                      <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
+                      </svg>
+                      <span className="text-sm font-medium">Adjuntar imagen o PDF</span>
+                      <span className="text-xs text-slate-400">Máx {MAX_PROOF_MB} MB</span>
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-3 rounded-xl border border-gray-100 bg-slate-50 p-3">
+                      {proof.isImage ? (
+                        <img src={proof.dataUrl} alt={proof.name} className="h-14 w-14 shrink-0 rounded-lg object-cover" />
+                      ) : (
+                        <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-lg bg-red-50 text-red-500">
+                          <svg className="h-7 w-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                          </svg>
+                        </div>
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium text-slate-900">{proof.name}</p>
+                        <p className="text-xs text-slate-500">Listo para enviar</p>
+                      </div>
+                      <button onClick={() => setProof(null)} className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50">
+                        Quitar
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                <div>
+                  <label className="mb-1.5 block text-sm font-semibold text-slate-900">Referencia (opcional)</label>
+                  <input
+                    type="text"
+                    value={reference}
+                    onChange={(e) => setReference(e.target.value)}
+                    placeholder="N.º de referencia de la transferencia"
+                    className="w-full rounded-xl border border-gray-200 px-4 py-2.5 text-sm text-slate-800 placeholder:text-slate-400 outline-none transition focus:border-steelblue-200 focus:ring-2 focus:ring-steelblue-100"
+                  />
+                </div>
+
+                <button
+                  onClick={handleSubmitTransfer}
+                  disabled={submitting || !proof}
+                  className="flex w-full items-center justify-center gap-2 rounded-xl bg-steelblue-300 py-3 font-semibold text-white shadow-lg shadow-steelblue-300/20 transition hover:bg-steelblue-200 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting && <span className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />}
+                  {submitting ? 'Enviando...' : 'Enviar comprobante'}
+                </button>
+              </div>
+            )}
+
+            {/* --- Tarjeta (placeholder) --- */}
+            {tab === 'card' && (
+              <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-gray-200 py-14 text-center">
+                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-steelblue-100/40 text-steelblue-300">
+                  <svg className="h-7 w-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
+                  </svg>
+                </div>
+                <p className="text-base font-semibold text-slate-800">Pago con tarjeta</p>
+                <p className="max-w-xs text-sm text-slate-500">
+                  Esta opción se está construyendo. Muy pronto podrás pagar y activar el cobro automático con tu tarjeta.
+                </p>
+                <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700">En construcción</span>
+              </div>
+            )}
+
+            {/* --- Historial --- */}
+            {tab === 'history' && (
+              <div className="space-y-3">
+                {history.length === 0 ? (
+                  <div className="rounded-xl border border-dashed border-gray-200 py-12 text-center text-sm text-slate-500">
+                    Aún no tienes pagos registrados.
+                  </div>
+                ) : (
+                  history.map((p) => {
+                    const meta = statusMeta(p.status);
+                    return (
+                      <div key={p.id} className="flex items-center justify-between gap-3 rounded-xl border border-gray-100 p-4">
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold capitalize text-slate-900">{p.periodLabel}</p>
+                          <p className="text-xs text-slate-500">
+                            {money(p.amount)} · {p.method === 'card' ? 'Tarjeta' : 'Transferencia'}
+                          </p>
+                        </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${meta.cls}`}>{meta.label}</span>
+                          {p.status === 'confirmed' && (
+                            <button
+                              onClick={() => handleDownloadTicket(p.id)}
+                              disabled={downloadingId === p.id}
+                              className="rounded-lg bg-steelblue-300 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-steelblue-200 disabled:opacity-60"
+                            >
+                              {downloadingId === p.id ? '...' : 'Ticket'}
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <ToastContainer position="top-center" autoClose={3500} theme="light" />
+    </div>
+  );
+};
+
+export default PagoServicio;

--- a/dte-web-app/src/pages/PaymentsAdmin.jsx
+++ b/dte-web-app/src/pages/PaymentsAdmin.jsx
@@ -1,0 +1,398 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import PaymentService from '../services/PaymentService';
+
+const MONTHS = ['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'];
+
+const labelFor = (period) => {
+  const [y, m] = String(period || '').split('-');
+  const idx = Number(m) - 1;
+  return idx >= 0 && idx < 12 ? `${MONTHS[idx]} ${y}` : period;
+};
+
+const shiftPeriod = (period, delta) => {
+  const [y, m] = period.split('-').map(Number);
+  const d = new Date(y, m - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+};
+
+const money = (v) => `$${Number(v || 0).toFixed(2)}`;
+
+// Convierte un dataURL base64 a un blob URL (más confiable para abrir PDFs).
+const dataUrlToBlobUrl = (dataUrl) => {
+  const [header, base64] = String(dataUrl).split(',');
+  const mime = header.match(/:(.*?);/)?.[1] || 'application/octet-stream';
+  const binary = window.atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return window.URL.createObjectURL(new Blob([bytes], { type: mime }));
+};
+
+const statusMeta = (status) => {
+  switch (status) {
+    case 'confirmed':
+      return { label: 'Recibido', cls: 'bg-emerald-100 text-emerald-700' };
+    case 'pending':
+      return { label: 'En revisión', cls: 'bg-amber-100 text-amber-700' };
+    case 'rejected':
+      return { label: 'Rechazado', cls: 'bg-red-100 text-red-700' };
+    default:
+      return { label: 'Sin pago', cls: 'bg-slate-100 text-slate-500' };
+  }
+};
+
+const PaymentsAdmin = () => {
+  const token = localStorage.getItem('token');
+  const currentUserId = Number(localStorage.getItem('user_id'));
+  const navigate = useNavigate();
+
+  const [period, setPeriod] = useState(null);
+  const [clients, setClients] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const [selected, setSelected] = useState(null);
+  const [detail, setDetail] = useState([]);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [amountDraft, setAmountDraft] = useState('');
+  const [savingAmount, setSavingAmount] = useState(false);
+  const [reviewingId, setReviewingId] = useState(null);
+  const [proofView, setProofView] = useState(null); // { mime, data, name }
+  const [proofLoading, setProofLoading] = useState(false);
+
+  const loadClients = async (targetPeriod) => {
+    setLoading(true);
+    try {
+      const data = await PaymentService.adminGetClients(token, targetPeriod);
+      setPeriod(data.period);
+      setClients(Array.isArray(data.clients) ? data.clients : []);
+    } catch (error) {
+      console.error('Error al cargar clientes', error);
+      toast.error('No se pudieron cargar los pagos');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (currentUserId !== 1) {
+      navigate('/principal');
+      return;
+    }
+    loadClients();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const openClient = async (client) => {
+    setSelected(client);
+    setAmountDraft(String(client.amount ?? ''));
+    setDetailLoading(true);
+    try {
+      const rows = await PaymentService.adminGetUserPayments(client.user_id, token);
+      setDetail(Array.isArray(rows) ? rows : []);
+    } catch (error) {
+      console.error('Error al cargar historial', error);
+      toast.error('No se pudo cargar el historial');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const closeDetail = () => {
+    setSelected(null);
+    setDetail([]);
+    setProofView(null);
+  };
+
+  const refreshAfterChange = async () => {
+    await loadClients(period);
+    if (selected) {
+      const rows = await PaymentService.adminGetUserPayments(selected.user_id, token);
+      setDetail(Array.isArray(rows) ? rows : []);
+    }
+  };
+
+  const handleReview = async (paymentId, action) => {
+    setReviewingId(paymentId);
+    try {
+      await PaymentService.adminReview(paymentId, token, action);
+      toast.success(action === 'confirm' ? 'Pago confirmado' : 'Pago rechazado');
+      await refreshAfterChange();
+    } catch (error) {
+      console.error('Error al revisar el pago', error);
+      toast.error(error?.message || 'No se pudo actualizar el pago');
+    } finally {
+      setReviewingId(null);
+    }
+  };
+
+  const handleViewProof = async (paymentId) => {
+    setProofLoading(true);
+    try {
+      const data = await PaymentService.getProof(paymentId, token);
+      const isImage = String(data.proof_mime || '').startsWith('image/');
+      if (isImage) {
+        setProofView({ data: data.proof, mime: data.proof_mime, name: data.proof_name });
+      } else {
+        // PDF u otro: abrir en pestaña nueva vía blob.
+        const url = dataUrlToBlobUrl(data.proof);
+        window.open(url, '_blank', 'noopener');
+        setTimeout(() => window.URL.revokeObjectURL(url), 60000);
+        setProofView(null);
+      }
+    } catch (error) {
+      console.error('Error al ver el comprobante', error);
+      toast.error(error?.message || 'No se pudo abrir el comprobante');
+    } finally {
+      setProofLoading(false);
+    }
+  };
+
+  const handleDownloadTicket = async (paymentId) => {
+    try {
+      const url = await PaymentService.getTicketBlobUrl(paymentId, token);
+      window.open(url, '_blank', 'noopener');
+      setTimeout(() => window.URL.revokeObjectURL(url), 60000);
+    } catch (error) {
+      toast.error(error?.message || 'No se pudo descargar el ticket');
+    }
+  };
+
+  const handleSaveAmount = async () => {
+    const value = Number(amountDraft);
+    if (Number.isNaN(value) || value < 0) {
+      toast.info('Ingresa un monto válido');
+      return;
+    }
+    setSavingAmount(true);
+    try {
+      await PaymentService.adminSetAmount(selected.user_id, token, value);
+      toast.success('Monto actualizado');
+      await refreshAfterChange();
+      setSelected((prev) => (prev ? { ...prev, amount: value, configured: true } : prev));
+    } catch (error) {
+      console.error('Error al guardar el monto', error);
+      toast.error(error?.message || 'No se pudo guardar el monto');
+    } finally {
+      setSavingAmount(false);
+    }
+  };
+
+  const receivedCount = clients.filter((c) => c.period_status === 'confirmed').length;
+  const pendingCount = clients.filter((c) => c.period_status === 'pending').length;
+
+  return (
+    <div className="min-h-screen bg-steelblue-300 px-3 py-6 sm:px-6 sm:py-10 animate-fadeIn">
+      <div className="mx-auto w-full max-w-5xl overflow-hidden rounded-2xl border border-white/20 bg-white shadow-2xl">
+        {/* Header */}
+        <header className="flex items-center justify-between gap-3 border-b border-gray-100 bg-steelblue-300 px-4 py-3 sm:px-6 sm:py-4">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/25 sm:h-11 sm:w-11">
+              <svg className="h-5 w-5 text-white sm:h-6 sm:w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 7h6m-6 4h6m-6 4h4M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z" />
+              </svg>
+            </div>
+            <div className="min-w-0">
+              <h1 className="truncate text-base font-semibold leading-tight text-white sm:text-lg">Pagos</h1>
+              <p className="truncate text-xs text-white/80">Validación y precios de clientes</p>
+            </div>
+          </div>
+          <button
+            onClick={() => (selected ? closeDetail() : navigate('/principal'))}
+            className="shrink-0 rounded-full border border-white/25 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/25 sm:px-4 sm:py-2 sm:text-sm"
+          >
+            {selected ? 'Atrás' : 'Volver'}
+          </button>
+        </header>
+
+        {/* Selector de periodo */}
+        <div className="flex items-center justify-between gap-3 border-b border-gray-100 px-4 py-3 sm:px-6">
+          <button
+            onClick={() => loadClients(shiftPeriod(period, -1))}
+            disabled={!period || loading}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
+          >
+            ‹
+          </button>
+          <div className="text-center">
+            <p className="text-sm font-semibold capitalize text-slate-900">{period ? labelFor(period) : '...'}</p>
+            {!selected && (
+              <p className="text-xs text-slate-500">
+                {receivedCount} recibidos · {pendingCount} en revisión
+              </p>
+            )}
+          </div>
+          <button
+            onClick={() => loadClients(shiftPeriod(period, 1))}
+            disabled={!period || loading}
+            className="rounded-lg border border-gray-200 px-3 py-1.5 text-sm text-slate-600 transition hover:bg-slate-50 disabled:opacity-50"
+          >
+            ›
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-20">
+            <div className="h-9 w-9 animate-spin rounded-full border-4 border-steelblue-200 border-t-transparent" />
+          </div>
+        ) : selected ? (
+          /* ---------- Detalle de cliente ---------- */
+          <div className="p-4 sm:p-6">
+            <div className="mb-4">
+              <h2 className="text-lg font-semibold text-slate-900">{selected.name}</h2>
+              <p className="text-xs text-slate-500">@{selected.username} · #{selected.user_id}</p>
+            </div>
+
+            {/* Editar monto */}
+            <div className="mb-5 rounded-xl border border-gray-100 p-4">
+              <label className="mb-1.5 block text-sm font-semibold text-slate-900">Monto mensual</label>
+              <div className="flex items-center gap-2">
+                <span className="text-slate-500">$</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={amountDraft}
+                  onChange={(e) => setAmountDraft(e.target.value)}
+                  className="w-32 rounded-lg border border-gray-200 px-3 py-2 text-sm text-slate-800 outline-none focus:border-steelblue-200 focus:ring-2 focus:ring-steelblue-100"
+                />
+                <button
+                  onClick={handleSaveAmount}
+                  disabled={savingAmount}
+                  className="rounded-lg bg-steelblue-300 px-4 py-2 text-sm font-semibold text-white transition hover:bg-steelblue-200 disabled:opacity-60"
+                >
+                  {savingAmount ? '...' : 'Guardar'}
+                </button>
+                {!selected.configured && (
+                  <span className="text-xs text-amber-600">Placeholder</span>
+                )}
+              </div>
+            </div>
+
+            {/* Historial de pagos */}
+            <p className="mb-2 text-sm font-semibold text-slate-900">Historial</p>
+            {detailLoading ? (
+              <div className="flex items-center justify-center py-10">
+                <div className="h-7 w-7 animate-spin rounded-full border-4 border-steelblue-200 border-t-transparent" />
+              </div>
+            ) : detail.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-gray-200 py-10 text-center text-sm text-slate-500">
+                Sin pagos registrados.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {detail.map((p) => {
+                  const meta = statusMeta(p.status);
+                  return (
+                    <div key={p.id} className="rounded-xl border border-gray-100 p-4">
+                      <div className="flex items-center justify-between gap-3">
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold capitalize text-slate-900">{p.periodLabel}</p>
+                          <p className="text-xs text-slate-500">
+                            {money(p.amount)} · {p.method === 'card' ? 'Tarjeta' : 'Transferencia'}
+                            {p.reference ? ` · Ref: ${p.reference}` : ''}
+                          </p>
+                        </div>
+                        <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold ${meta.cls}`}>{meta.label}</span>
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {p.has_proof && (
+                          <button
+                            onClick={() => handleViewProof(p.id)}
+                            disabled={proofLoading}
+                            className="rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-50 disabled:opacity-60"
+                          >
+                            Ver comprobante
+                          </button>
+                        )}
+                        {p.status !== 'confirmed' && (
+                          <button
+                            onClick={() => handleReview(p.id, 'confirm')}
+                            disabled={reviewingId === p.id}
+                            className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-400 disabled:opacity-60"
+                          >
+                            {reviewingId === p.id ? '...' : 'Confirmar recibido'}
+                          </button>
+                        )}
+                        {p.status === 'pending' && (
+                          <button
+                            onClick={() => handleReview(p.id, 'reject')}
+                            disabled={reviewingId === p.id}
+                            className="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 transition hover:bg-red-50 disabled:opacity-60"
+                          >
+                            Rechazar
+                          </button>
+                        )}
+                        {p.status === 'confirmed' && (
+                          <button
+                            onClick={() => handleDownloadTicket(p.id)}
+                            className="rounded-lg bg-steelblue-300 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-steelblue-200"
+                          >
+                            Descargar ticket
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        ) : (
+          /* ---------- Lista de clientes ---------- */
+          <div className="p-4 sm:p-6">
+            {clients.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-gray-200 py-12 text-center text-sm text-slate-500">
+                No hay clientes.
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {clients.map((c) => {
+                  const meta = statusMeta(c.period_status);
+                  return (
+                    <button
+                      key={c.user_id}
+                      onClick={() => openClient(c)}
+                      className="flex w-full items-center justify-between gap-3 rounded-xl border border-gray-100 p-4 text-left transition hover:bg-slate-50"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-slate-900">{c.name}</p>
+                        <p className="truncate text-xs text-slate-500">
+                          @{c.username} · {money(c.amount)}{!c.configured ? ' (placeholder)' : ''}
+                        </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        {c.payment?.has_proof && c.period_status === 'pending' && (
+                          <span className="h-2 w-2 rounded-full bg-amber-500" title="Comprobante por revisar" />
+                        )}
+                        <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${meta.cls}`}>{meta.label}</span>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Modal de comprobante (imagen) */}
+      {proofView && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setProofView(null)}
+        >
+          <div className="max-h-[90vh] max-w-3xl overflow-auto rounded-xl bg-white p-2" onClick={(e) => e.stopPropagation()}>
+            <img src={proofView.data} alt={proofView.name || 'Comprobante'} className="h-auto w-full rounded-lg" />
+          </div>
+        </div>
+      )}
+
+      <ToastContainer position="top-center" autoClose={3000} theme="light" />
+    </div>
+  );
+};
+
+export default PaymentsAdmin;

--- a/dte-web-app/src/pages/SupportChat.jsx
+++ b/dte-web-app/src/pages/SupportChat.jsx
@@ -84,6 +84,7 @@ const SupportChat = ({ mode = 'user' }) => {
 
   const bottomRef = useRef(null);
   const attachmentInputRef = useRef(null);
+  const composerRef = useRef(null);
 
   const activeThreadLabel = useMemo(() => {
     if (isAdmin) {
@@ -211,7 +212,7 @@ const SupportChat = ({ mode = 'user' }) => {
   const handleSend = async (event) => {
     event.preventDefault();
 
-    if (!draft.trim() || !selectedUserId) {
+    if ((!draft.trim() && !attachment) || !selectedUserId) {
       return;
     }
 
@@ -224,6 +225,9 @@ const SupportChat = ({ mode = 'user' }) => {
       await SupportChatService.sendMessage(token, selectedUserId, payload);
       setDraft('');
       setAttachment(null);
+      if (composerRef.current) {
+        composerRef.current.style.height = 'auto';
+      }
       await loadMessages(selectedUserId);
       if (isAdmin) {
         await loadThreads();
@@ -236,40 +240,73 @@ const SupportChat = ({ mode = 'user' }) => {
     }
   };
 
-  const chatSubtitle = isAdmin
-    ? 'Selecciona una conversación y responde desde soporte.'
-    : 'Escribe aquí tu duda y soporte te responderá en este mismo chat.';
+  const handleComposerInput = (event) => {
+    setDraft(event.target.value);
+    const el = event.target;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 128)}px`;
+  };
+
+  const handleComposerKeyDown = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      handleSend(event);
+    }
+  };
+
+  const formatMessageTime = (value) => {
+    try {
+      return new Date(value).toLocaleString('es-ES', {
+        day: '2-digit',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  };
+
+  const canSend = Boolean((draft.trim() || attachment) && selectedUserId);
 
   return (
-    <div className="h-[calc(100dvh-66px)] min-h-[calc(100dvh-66px)] overflow-hidden bg-steelblue-300 text-slate-900 pt-[66px]">
-      <div className="mx-auto flex h-full max-w-7xl px-4 sm:px-6 lg:px-8 2xl:max-w-[1600px]">
-        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl">
-          <header className="border-b border-gray-200 bg-gradient-to-r from-steelblue-300 via-steelblue-200 to-deepskyblue px-5 py-4 sm:px-6">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <p className="text-xs uppercase tracking-[0.28em] text-white/80">Centro de soporte</p>
-                <h1 className="mt-1 text-2xl sm:text-3xl font-semibold text-white">Chat {isAdmin ? 'de soporte' : 'con soporte'}</h1>
-                <p className="mt-1 text-sm text-white/90 max-w-2xl">{chatSubtitle}</p>
+    <div className="flex h-[calc(100dvh-66px)] min-h-[calc(100dvh-66px)] flex-col overflow-hidden bg-steelblue-300 pt-[66px]">
+      <div className={`mx-auto flex h-full w-full px-3 py-3 sm:px-6 sm:py-5 lg:px-8 ${isAdmin ? 'max-w-7xl 2xl:max-w-[1600px]' : 'max-w-3xl'}`}>
+        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-white/20 bg-white shadow-2xl">
+          {/* Header */}
+          <header className="flex items-center justify-between gap-3 border-b border-gray-100 bg-steelblue-300 px-4 py-3 sm:px-6 sm:py-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/25 sm:h-11 sm:w-11">
+                <svg className="h-5 w-5 text-white sm:h-6 sm:w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h8m-8 4h5m1 5l-3 3-3-3h-2a4 4 0 01-4-4V6a4 4 0 014-4h12a4 4 0 014 4v8a4 4 0 01-4 4h-3z" />
+                </svg>
               </div>
-              <button
-                onClick={() => navigate('/principal')}
-                className="rounded-full border border-white/30 bg-white/15 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/25"
-              >
-                Volver
-              </button>
+              <div className="min-w-0">
+                <h1 className="truncate text-base font-semibold leading-tight text-white sm:text-lg">
+                  {isAdmin ? 'Panel de soporte' : 'Soporte'}
+                </h1>
+                <div className="flex items-center gap-1.5 text-xs text-white/80">
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-400" />
+                  <span className="truncate">
+                    {isAdmin ? activeThreadLabel : 'En línea · te responderemos aquí'}
+                  </span>
+                </div>
+              </div>
             </div>
+            <button
+              onClick={() => navigate('/principal')}
+              className="shrink-0 rounded-full border border-white/25 bg-white/10 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-white/25 sm:px-4 sm:py-2 sm:text-sm"
+            >
+              Volver
+            </button>
           </header>
 
-          <div className="grid min-h-0 flex-1 overflow-hidden lg:grid-cols-[340px_minmax(0,1fr)] xl:grid-cols-[380px_minmax(0,1fr)]">
+          <div className={`grid min-h-0 flex-1 overflow-hidden ${isAdmin ? 'lg:grid-cols-[300px_minmax(0,1fr)] xl:grid-cols-[340px_minmax(0,1fr)]' : ''}`}>
             {isAdmin && (
-              <aside className="min-h-0 border-r border-gray-200 bg-white p-4 sm:p-5 lg:flex lg:flex-col lg:gap-4 lg:overflow-y-auto">
-                <div className="mb-4 flex items-center justify-between">
-                  <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-600">Conversaciones</h2>
-                  <span className="rounded-full bg-steelblue-100 px-3 py-1 text-xs text-white">{threads.length}</span>
-                </div>
-                <div className="rounded-2xl border border-gray-200 bg-slate-50 p-3 text-sm text-slate-600 lg:block">
-                  <p className="font-semibold text-slate-900">Panel de soporte</p>
-                  <p className="mt-1 text-xs leading-5">Aquí puedes cambiar entre chats de clientes, responder y revisar mensajes anteriores.</p>
+              <aside className="hidden min-h-0 flex-col gap-3 border-r border-gray-100 bg-white p-4 lg:flex lg:overflow-y-auto">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Conversaciones</h2>
+                  <span className="rounded-full bg-steelblue-300 px-2.5 py-0.5 text-xs font-medium text-white">{threads.length}</span>
                 </div>
                 <div className="space-y-2">
                   {threads.length > 0 ? (
@@ -279,7 +316,7 @@ const SupportChat = ({ mode = 'user' }) => {
                         <button
                           key={thread.user_id}
                           onClick={() => setSelectedUserId(String(thread.user_id))}
-                          className={`w-full rounded-2xl border px-4 py-3 text-left transition ${isActive ? 'border-steelblue-200 bg-blue-50' : 'border-gray-200 bg-white hover:bg-slate-50'}`}
+                          className={`w-full rounded-xl border px-4 py-3 text-left transition ${isActive ? 'border-steelblue-200 bg-blue-50' : 'border-gray-100 bg-white hover:bg-slate-50'}`}
                         >
                           <div className="flex items-start justify-between gap-3">
                             <div className="min-w-0">
@@ -294,7 +331,7 @@ const SupportChat = ({ mode = 'user' }) => {
                       );
                     })
                   ) : (
-                    <div className="rounded-2xl border border-dashed border-gray-200 bg-slate-50 p-4 text-sm text-slate-500">
+                    <div className="rounded-xl border border-dashed border-gray-200 bg-slate-50 p-4 text-sm text-slate-500">
                       No hay conversaciones aún.
                     </div>
                   )}
@@ -303,48 +340,72 @@ const SupportChat = ({ mode = 'user' }) => {
             )}
 
             <section className="flex min-h-0 min-w-0 flex-col bg-white">
-              <div className="border-b border-gray-200 px-5 py-4 sm:px-6">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Conversación activa</p>
-                    <h2 className="text-lg font-semibold text-slate-900">{activeThreadLabel}</h2>
-                  </div>
-                  {!isAdmin && (
-                    <div className="rounded-full bg-green-50 px-3 py-1 text-xs font-medium text-green-700">
-                      Soporte responderá aquí
-                    </div>
-                  )}
+              {/* Selector de conversación en móvil (admin) */}
+              {isAdmin && (
+                <div className="border-b border-gray-100 px-3 py-2.5 sm:px-6 lg:hidden">
+                  <select
+                    value={selectedUserId}
+                    onChange={(event) => setSelectedUserId(event.target.value)}
+                    className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm text-slate-800 outline-none focus:border-steelblue-200"
+                  >
+                    <option value="">Selecciona una conversación</option>
+                    {threads.map((thread) => (
+                      <option key={thread.user_id} value={String(thread.user_id)}>
+                        {(thread.sender_name || `Usuario #${thread.user_id}`)}{thread.unread_count > 0 ? ` (${thread.unread_count})` : ''}
+                      </option>
+                    ))}
+                  </select>
                 </div>
-              </div>
+              )}
 
-              <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden bg-slate-50 px-4 py-5 sm:px-6">
+              {/* Mensajes */}
+              <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden bg-slate-50 px-3 py-4 sm:px-6 sm:py-6">
                 {loading ? (
-                  <div className="flex min-h-[320px] items-center justify-center">
-                    <div className="flex flex-col items-center gap-3 text-slate-500">
-                      <div className="h-10 w-10 animate-spin rounded-full border-4 border-steelblue-200 border-t-transparent" />
-                      <span>Cargando chat...</span>
+                  <div className="flex min-h-[280px] items-center justify-center">
+                    <div className="flex flex-col items-center gap-3 text-slate-400">
+                      <div className="h-9 w-9 animate-spin rounded-full border-4 border-steelblue-200 border-t-transparent" />
+                      <span className="text-sm">Cargando chat...</span>
                     </div>
                   </div>
                 ) : messages.length > 0 ? (
-                  <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+                  <div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
                     {messages.map((message) => {
                       const parsedContent = parseMessageContent(message.message);
                       const isOwnMessage = message.sender_role === currentRole;
                       return (
                         <article key={message.id} className={`flex ${isOwnMessage ? 'justify-end' : 'justify-start'}`}>
-                          <div className={`max-w-[min(85%,42rem)] rounded-3xl px-4 py-3 shadow-sm ${isOwnMessage ? 'bg-steelblue-300 text-white' : 'border border-gray-200 bg-white text-slate-800'}`}>
-                            <div className="mb-1 flex items-center justify-between gap-3 text-[11px] uppercase tracking-[0.18em] opacity-80">
-                              <span>{message.sender_name}</span>
-                              <span>{new Date(message.created_at).toLocaleString('es-ES')}</span>
+                          <div className={`max-w-[82%] sm:max-w-[70%] ${isOwnMessage ? 'items-end' : 'items-start'} flex flex-col`}>
+                            {!isOwnMessage && (
+                              <span className="mb-1 px-1 text-[11px] font-medium text-slate-400">{message.sender_name}</span>
+                            )}
+                            <div
+                              className={`rounded-2xl px-3.5 py-2.5 text-sm leading-relaxed shadow-sm ${
+                                isOwnMessage
+                                  ? 'rounded-br-md bg-steelblue-300 text-white'
+                                  : 'rounded-bl-md border border-gray-100 bg-white text-slate-800'
+                              }`}
+                            >
+                              {parsedContent.text && (
+                                <p className="whitespace-pre-wrap break-words">{parsedContent.text}</p>
+                              )}
+                              {parsedContent.attachment?.dataUrl && (
+                                <a
+                                  href={parsedContent.attachment.dataUrl}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                  className={`block overflow-hidden rounded-xl ${parsedContent.text ? 'mt-2' : ''} ${isOwnMessage ? 'bg-white/10' : 'bg-black/5'}`}
+                                >
+                                  <img
+                                    src={parsedContent.attachment.dataUrl}
+                                    alt={parsedContent.attachment.name || 'Adjunto'}
+                                    className="max-h-64 w-full object-cover"
+                                  />
+                                </a>
+                              )}
                             </div>
-                            {parsedContent.text && (
-                              <p className="whitespace-pre-wrap text-sm leading-6">{parsedContent.text}</p>
-                            )}
-                            {parsedContent.attachment?.dataUrl && (
-                              <a href={parsedContent.attachment.dataUrl} target="_blank" rel="noreferrer" className="mt-3 block overflow-hidden rounded-2xl border border-white/20 bg-black/5">
-                                <img src={parsedContent.attachment.dataUrl} alt={parsedContent.attachment.name || 'Adjunto'} className="max-h-72 w-full object-cover" />
-                              </a>
-                            )}
+                            <span className={`mt-1 px-1 text-[10px] text-slate-400 ${isOwnMessage ? 'text-right' : 'text-left'}`}>
+                              {formatMessageTime(message.created_at)}
+                            </span>
                           </div>
                         </article>
                       );
@@ -352,17 +413,25 @@ const SupportChat = ({ mode = 'user' }) => {
                     <div ref={bottomRef} />
                   </div>
                 ) : (
-                  <div className="flex min-h-[320px] items-center justify-center">
-                    <div className="rounded-3xl border border-dashed border-gray-200 bg-white px-6 py-8 text-center text-slate-500">
-                      <p className="text-base font-medium text-slate-900">Todavía no hay mensajes</p>
-                      <p className="mt-1 text-sm">Envía el primer mensaje para abrir el hilo.</p>
+                  <div className="flex min-h-[280px] items-center justify-center px-4">
+                    <div className="flex flex-col items-center gap-2 text-center">
+                      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-steelblue-100/40 text-steelblue-300">
+                        <svg className="h-7 w-7" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h8m-8 4h5m1 5l-3 3-3-3h-2a4 4 0 01-4-4V6a4 4 0 014-4h12a4 4 0 014 4v8a4 4 0 01-4 4h-3z" />
+                        </svg>
+                      </div>
+                      <p className="text-base font-medium text-slate-800">Todavía no hay mensajes</p>
+                      <p className="text-sm text-slate-500">
+                        {isAdmin ? 'Selecciona o responde una conversación.' : 'Escribe tu duda y soporte te responderá aquí.'}
+                      </p>
                     </div>
                   </div>
                 )}
               </div>
 
-              <div className="border-t border-gray-200 bg-white px-4 py-4 sm:px-6">
-                {error && <p className="mb-3 text-sm text-red-600">{error}</p>}
+              {/* Composer */}
+              <div className="border-t border-gray-100 bg-white px-3 py-3 sm:px-6 sm:py-4">
+                {error && <p className="mb-2 text-sm text-red-600">{error}</p>}
                 <input
                   ref={attachmentInputRef}
                   type="file"
@@ -371,42 +440,58 @@ const SupportChat = ({ mode = 'user' }) => {
                   onChange={handleAttachmentChange}
                 />
                 {attachment && (
-                  <div className="mb-3 flex items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-                    <div className="min-w-0">
-                      <p className="truncate font-medium text-slate-900">{attachment.name}</p>
+                  <div className="mb-2 flex items-center gap-3 rounded-xl border border-gray-100 bg-slate-50 px-3 py-2">
+                    {attachment.dataUrl && (
+                      <img src={attachment.dataUrl} alt={attachment.name} className="h-10 w-10 shrink-0 rounded-lg object-cover" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-slate-900">{attachment.name}</p>
                       <p className="text-xs text-slate-500">Imagen lista para enviar</p>
                     </div>
-                    <button type="button" onClick={removeAttachment} className="rounded-full bg-white px-3 py-1 text-xs font-semibold text-red-600 shadow-sm ring-1 ring-gray-200 transition hover:bg-red-50">
+                    <button
+                      type="button"
+                      onClick={removeAttachment}
+                      className="shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold text-red-600 transition hover:bg-red-50"
+                    >
                       Quitar
                     </button>
                   </div>
                 )}
-                <form onSubmit={handleSend} className="flex flex-col gap-3 sm:flex-row xl:flex-nowrap">
-                  <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row xl:flex-nowrap">
-                    <textarea
-                      value={draft}
-                      onChange={(event) => setDraft(event.target.value)}
-                      rows={3}
-                      className="min-h-[92px] w-full flex-1 resize-none rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 outline-none transition focus:border-steelblue-200 focus:ring-2 focus:ring-steelblue-100"
-                      placeholder={isAdmin ? 'Responder al usuario...' : 'Escribe tu mensaje de soporte...'}
-                    />
-                    <div className="flex gap-2 sm:w-44 sm:flex-col xl:w-48">
-                      <button
-                        type="button"
-                        onClick={openAttachmentPicker}
-                        className="inline-flex items-center justify-center rounded-2xl border border-gray-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:bg-slate-50"
-                      >
-                        Subir foto
-                      </button>
-                      <button
-                        type="submit"
-                        disabled={sending || (!draft.trim() && !attachment)}
-                        className="inline-flex items-center justify-center rounded-2xl bg-steelblue-300 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-steelblue-300/20 transition hover:bg-steelblue-200 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        {sending ? 'Enviando...' : 'Enviar'}
-                      </button>
-                    </div>
-                  </div>
+                <form onSubmit={handleSend} className="flex items-end gap-2">
+                  <button
+                    type="button"
+                    onClick={openAttachmentPicker}
+                    title="Adjuntar imagen"
+                    aria-label="Adjuntar imagen"
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-white text-slate-500 transition hover:bg-slate-50 hover:text-steelblue-300"
+                  >
+                    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" />
+                    </svg>
+                  </button>
+                  <textarea
+                    ref={composerRef}
+                    value={draft}
+                    onChange={handleComposerInput}
+                    onKeyDown={handleComposerKeyDown}
+                    rows={1}
+                    className="max-h-32 min-h-[44px] w-full flex-1 resize-none rounded-2xl border border-gray-200 bg-white px-4 py-2.5 text-sm text-slate-800 placeholder:text-slate-400 outline-none transition focus:border-steelblue-200 focus:ring-2 focus:ring-steelblue-100"
+                    placeholder={isAdmin ? 'Responder al usuario...' : 'Escribe tu mensaje...'}
+                  />
+                  <button
+                    type="submit"
+                    disabled={sending || !canSend}
+                    aria-label="Enviar mensaje"
+                    className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-steelblue-300 text-white shadow-lg shadow-steelblue-300/20 transition hover:bg-steelblue-200 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {sending ? (
+                      <div className="h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" />
+                    ) : (
+                      <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 19l0-14M5 12l7-7 7 7" />
+                      </svg>
+                    )}
+                  </button>
                 </form>
               </div>
             </section>

--- a/dte-web-app/src/services/AnnouncementService.js
+++ b/dte-web-app/src/services/AnnouncementService.js
@@ -1,0 +1,47 @@
+const BASE_URL = "https://intuitive-bravery-production.up.railway.app";
+
+const AnnouncementService = {
+  // Anuncio activo que ven los clientes en el home principal.
+  getCurrent: async (token) => {
+    const res = await fetch(`${BASE_URL}/announcements/current`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return res.json();
+  },
+
+  // Admin: configuración completa para editar.
+  getAdmin: async (token) => {
+    const res = await fetch(`${BASE_URL}/announcements`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return res.json();
+  },
+
+  // Admin: actualiza mensaje y/o toggle.
+  update: async (token, { message, enabled }) => {
+    const res = await fetch(`${BASE_URL}/announcements`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ message, enabled }),
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return res.json();
+  },
+};
+
+export default AnnouncementService;

--- a/dte-web-app/src/services/PaymentService.js
+++ b/dte-web-app/src/services/PaymentService.js
@@ -1,0 +1,102 @@
+const BASE_URL = "https://intuitive-bravery-production.up.railway.app";
+
+const authHeaders = (token) => ({ Authorization: `Bearer ${token}` });
+
+const parseJson = async (res) => {
+  if (!res.ok) {
+    let message = `HTTP ${res.status}`;
+    try {
+      const data = await res.json();
+      message = data?.message || message;
+    } catch {
+      /* noop */
+    }
+    throw new Error(message);
+  }
+  return res.json();
+};
+
+const PaymentService = {
+  // Estado del ciclo de pago del usuario (para las notificaciones).
+  getStatus: async (userId, token) => {
+    const res = await fetch(`${BASE_URL}/payments/status/${userId}`, { headers: authHeaders(token) });
+    return parseJson(res);
+  },
+
+  // Datos de suscripción: monto del mes + estado del periodo.
+  getSubscription: async (userId, token) => {
+    const res = await fetch(`${BASE_URL}/payments/subscription/${userId}`, { headers: authHeaders(token) });
+    return parseJson(res);
+  },
+
+  // Cliente: enviar comprobante de transferencia (dataURL base64).
+  submitTransfer: async (userId, token, payload) => {
+    const res = await fetch(`${BASE_URL}/payments/transfer/${userId}`, {
+      method: 'POST',
+      headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    return parseJson(res);
+  },
+
+  // Historial de pagos del cliente.
+  getMyPayments: async (userId, token) => {
+    const res = await fetch(`${BASE_URL}/payments/mine/${userId}`, { headers: authHeaders(token) });
+    return parseJson(res);
+  },
+
+  // Comprobante subido (imagen/PDF).
+  getProof: async (paymentId, token) => {
+    const res = await fetch(`${BASE_URL}/payments/proof/${paymentId}`, { headers: authHeaders(token) });
+    return parseJson(res);
+  },
+
+  // Descargar / abrir el ticket PDF (devuelve un objeto URL para blob).
+  getTicketBlobUrl: async (paymentId, token) => {
+    const res = await fetch(`${BASE_URL}/payments/ticket/${paymentId}`, { headers: authHeaders(token) });
+    if (!res.ok) {
+      let message = `HTTP ${res.status}`;
+      try {
+        const data = await res.json();
+        message = data?.message || message;
+      } catch {
+        /* noop */
+      }
+      throw new Error(message);
+    }
+    const blob = await res.blob();
+    return window.URL.createObjectURL(blob);
+  },
+
+  // ---- Admin ----
+  adminGetClients: async (token, period) => {
+    const query = period ? `?period=${encodeURIComponent(period)}` : '';
+    const res = await fetch(`${BASE_URL}/payments/admin/clients${query}`, { headers: authHeaders(token) });
+    return parseJson(res);
+  },
+
+  adminGetUserPayments: async (userId, token) => {
+    const res = await fetch(`${BASE_URL}/payments/admin/user/${userId}`, { headers: authHeaders(token) });
+    return parseJson(res);
+  },
+
+  adminReview: async (paymentId, token, action, note) => {
+    const res = await fetch(`${BASE_URL}/payments/admin/review/${paymentId}`, {
+      method: 'PUT',
+      headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action, note }),
+    });
+    return parseJson(res);
+  },
+
+  adminSetAmount: async (userId, token, amount, active) => {
+    const res = await fetch(`${BASE_URL}/payments/admin/amount/${userId}`, {
+      method: 'PUT',
+      headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount, active }),
+    });
+    return parseJson(res);
+  },
+};
+
+export default PaymentService;


### PR DESCRIPTION
## Resumen

Agrega el módulo de **pagos de servicio** y **notificaciones**, más el rediseño del chat de soporte.

### Notificaciones
- **Anuncio / changelogs** en el home principal: se muestra una sola vez por versión a cada cliente (se guarda la versión vista en `localStorage`). Panel admin (**solo id 1**) para editar el mensaje y activar/desactivar.
- **Toasts del ciclo de pago** en la lista de facturas (una vez por sesión): `al día` / `próximo` / `día de pago` / `pendiente` / `vencido`. Vence el **15**, **7 días** de gracia, aviso **3 días** antes. El día del mes se calcula en zona horaria de El Salvador (server en UTC).

### Pagos
- **Pantalla de pago de servicio** (menú hamburguesa, para todos): 
  - **Transferencia**: 2 cuentas bancarias *placeholder* (con copiar) + subir comprobante (imagen o PDF) + referencia.
  - **Tarjeta**: placeholder "en construcción" (Wompi tokenizado = fase 2).
  - **Historial**: descarga del ticket de meses confirmados.
- **Panel admin de pagos** (**solo id 1**): navegación por mes, lista de clientes con estado (Recibido / En revisión / Sin pago), ver comprobante (imagen en modal / PDF en pestaña), **confirmar recibido** / rechazar, editar monto por cliente e historial con descarga de ticket.
- **Ticket PDF** informativo con `pdfkit`, marcado como **no válido como comprobante fiscal (DTE/CFE)**.

### Backend
- Nuevas rutas `/announcements` y `/payments` (montadas en `app.js`).
- Controladores `announcementController` y `paymentController` con control de acceso (admin id 1 / dueño del recurso).

### UI
- Rediseño del **chat de soporte** (cliente + admin): responsive, minimal, mismo estilo de la app (header steelblue, tarjeta blanca, composer tipo mensajería con Enter para enviar). Corrige un bug de layout donde el chat del cliente se encajaba en desktop.
- Todo el módulo sigue la identidad visual (steelblue-300, tarjetas, headers con avatar, píldoras).

## Base de datos ⚠️
Requiere aplicar el SQL antes de usar los pagos. Las migraciones knex corren solas en el deploy, pero también se incluye SQL manual idempotente en [`API/migrations/_manual_payments.sql`](API/migrations/_manual_payments.sql):
- `service_payments` (+ columnas `proof_mime`, `proof_name`, `note`)
- `subscription_config` (lista de precios por cliente; monto placeholder $25.00 por defecto)
- `announcements`

## Pendiente / fase 2
- Integración de **Wompi**: tokenización de tarjeta, link de pago y cron de cobro recurrente el 15 + webhook.

## Notas de verificación
- Backend: sintaxis validada con `node --check`.
- Frontend: no se pudo compilar en el entorno (el `node_modules` de `dte-web-app` está vacío); JSX revisado manualmente y consistente con los patrones existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
