### PR TITLE
feat: sidebar acordeon y ajustes de UI/permisos

### DIFF
--- a/dte-web-app/src/components/SideBarComponent.jsx
+++ b/dte-web-app/src/components/SideBarComponent.jsx
@@ -1,30 +1,113 @@
-import { useNavigate } from "react-router-dom";
-import receipt from "../assets/imgs/receipt.png";
-import book from "../assets/imgs/book.png";
-import customers from "../assets/imgs/customers.png";
+import { useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+
+// Icono genérico (heroicon-style, stroke currentColor).
+const Icon = ({ d, className = "h-5 w-5" }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={d} />
+  </svg>
+);
+
+const PATHS = {
+  home: "M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6",
+  doc: "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z",
+  list: "M4 6h16M4 12h16M4 18h16",
+  plus: "M12 4v16m8-8H4",
+  ban: "M18.364 5.636L5.636 18.364M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+  info: "M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z",
+  users: "M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m6-1a4 4 0 10-8 0 4 4 0 008 0zm8-3a4 4 0 11-8 0 4 4 0 018 0z",
+  user: "M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z",
+  folder: "M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
+  download: "M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4",
+  chart: "M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z",
+  wallet: "M3 10h18M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
+  card: "M3 10h18M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z",
+  chat: "M8 10h8m-8 4h5m1 5l-3 3-3-3h-2a4 4 0 01-4-4V6a4 4 0 014-4h12a4 4 0 014 4v8a4 4 0 01-4 4h-3z",
+  shield: "M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z",
+  megaphone: "M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z",
+  logout: "M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1",
+  chevron: "M19 9l-7 7-7-7",
+};
 
 const GroupComponent = ({ visible, setVisible }) => {
   const navigate = useNavigate();
-
-  const GoHomeHandler = () => navigate("/principal");
-  const GoHomeFacturasHandler = () => navigate("/facturas");
-  const GoProfileHandler = () => navigate("/perfil");
-  const GoAddBillsHandler = () => navigate("/crear/factura");
-  const GoClientsHandler = () => navigate("/clientes");
-  const GoProveedoresHandler = () => navigate("/proveedores");
-  const GoAddServiceHandler = () => navigate("/items");
-  const GoCancelBill = () => navigate("/invalidar");
-  const GoBooksBill = () => navigate("/facturas/libros");
-  const GoDownloadDTEs = () => navigate("/descargar-dtes");
-  const GoSupportChat = () => navigate(isSupportAdmin ? "/testadmin/support-chat" : "/soporte");
-  const GoSupportAdmin = () => navigate("/testadmin/support-chat");
-  const GoPagoServicio = () => navigate("/pago");
-  const GoPagosAdmin = () => navigate("/testadmin/pagos");
-  const CloseHandler = () => navigate("/ingresar");
-  const currentUserId = Number(localStorage.getItem('user_id'));
-  const currentUserRole = Number(localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol'));
-  const isSupportAdmin = currentUserId === 1 || currentUserRole === 1;
+  const location = useLocation();
+  const currentUserId = Number(localStorage.getItem("user_id"));
+  // Solo el usuario id 1 es administrador (paneles de soporte, pagos y anuncios).
   const isMainAdmin = currentUserId === 1;
+
+  const sections = [
+    {
+      key: "dte",
+      label: "DTE's",
+      icon: PATHS.doc,
+      items: [
+        { label: "Lista de DTE", path: "/facturas", icon: PATHS.list },
+        { label: "Crear DTE", path: "/crear/factura", icon: PATHS.plus },
+        { label: "Invalidar DTE", path: "/invalidar", icon: PATHS.ban },
+      ],
+    },
+    {
+      key: "info",
+      label: "Información",
+      icon: PATHS.info,
+      items: [
+        { label: "Receptores", path: "/clientes", icon: PATHS.users },
+        { label: "Perfil", path: "/perfil", icon: PATHS.user },
+      ],
+    },
+    {
+      key: "conta",
+      label: "Documentos / Contabilidad",
+      icon: PATHS.folder,
+      items: [
+        { label: "Descargar DTE'S", path: "/descargar-dtes", icon: PATHS.download },
+        { label: "Reportes", path: "/facturas/libros", icon: PATHS.chart },
+      ],
+    },
+    {
+      key: "pagos",
+      label: "Pagos y soporte",
+      icon: PATHS.wallet,
+      items: [
+        { label: "Pago de servicio", path: "/pago", icon: PATHS.card },
+        { label: "Soporte / Chat", path: "/soporte", icon: PATHS.chat },
+      ],
+    },
+    ...(isMainAdmin
+      ? [
+          {
+            key: "admin",
+            label: "Administración",
+            icon: PATHS.shield,
+            admin: true,
+            items: [
+              { label: "Panel de soporte", path: "/testadmin/support-chat", icon: PATHS.chat },
+              { label: "Pagos (admin)", path: "/testadmin/pagos", icon: PATHS.wallet },
+              { label: "Anuncio / Changelogs", path: "/testadmin/changelog", icon: PATHS.megaphone },
+            ],
+          },
+        ]
+      : []),
+  ];
+
+  // Abre por defecto la sección que contiene la ruta actual.
+  const [open, setOpen] = useState(() => {
+    const initial = {};
+    sections.forEach((s) => {
+      initial[s.key] = s.items.some((it) => it.path === location.pathname);
+    });
+    return initial;
+  });
+
+  const toggle = (key) => setOpen((prev) => ({ ...prev, [key]: !prev[key] }));
+
+  const go = (path) => {
+    navigate(path);
+    setVisible(false);
+  };
+
+  const isActive = (path) => location.pathname === path;
 
   return (
     <>
@@ -43,94 +126,92 @@ const GroupComponent = ({ visible, setVisible }) => {
         }`}
         aria-hidden={!visible}
       >
-        <div className="flex items-center px-4 py-3 border-b">
-          <span className="text-sm font-semibold text-gray-700">Menú</span>
+        {/* Encabezado */}
+        <div className="flex items-center gap-2 px-4 py-3.5 bg-steelblue-300">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/15 ring-1 ring-white/25">
+            <Icon d={PATHS.doc} className="h-4 w-4 text-white" />
+          </div>
+          <span className="text-sm font-semibold tracking-wide text-white">Menú</span>
         </div>
 
-        <nav className="h-[calc(100vh-56px)] overflow-y-auto p-3 space-y-1">
-          <button onClick={GoHomeHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src="/workfromhome-2@2x.png" />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Home</span>
+        <nav className="h-[calc(100vh-57px)] overflow-y-auto p-3 space-y-1.5">
+          {/* Home */}
+          <button
+            onClick={() => go("/principal")}
+            className={`w-full flex items-center gap-3 rounded-lg px-3 py-2.5 transition ${
+              isActive("/principal")
+                ? "bg-blue-50 text-steelblue-300"
+                : "text-gray-700 hover:bg-slate-100"
+            }`}
+          >
+            <Icon d={PATHS.home} className="h-5 w-5" />
+            <span className="text-sm font-semibold">Home</span>
           </button>
 
-          <button onClick={GoHomeFacturasHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src="/facturasdepapel-1@2x.png" />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Facturas</span>
-          </button>
+          {/* Secciones */}
+          {sections.map((section) => {
+            const isOpen = open[section.key];
+            const hasActive = section.items.some((it) => isActive(it.path));
+            return (
+              <div key={section.key} className="rounded-lg">
+                <button
+                  onClick={() => toggle(section.key)}
+                  className={`w-full flex items-center gap-3 rounded-lg px-3 py-2.5 transition ${
+                    hasActive || isOpen
+                      ? "text-steelblue-300"
+                      : "text-gray-700 hover:bg-slate-100"
+                  }`}
+                >
+                  <Icon d={section.icon} className="h-5 w-5" />
+                  <span className="flex-1 text-left text-sm font-semibold">{section.label}</span>
+                  {section.admin && (
+                    <span className="rounded-full bg-blue-50 px-1.5 py-0.5 text-[10px] font-semibold text-steelblue-300">
+                      admin
+                    </span>
+                  )}
+                  <Icon
+                    d={PATHS.chevron}
+                    className={`h-4 w-4 shrink-0 transition-transform duration-300 ${isOpen ? "rotate-180" : ""}`}
+                  />
+                </button>
 
-          <button onClick={GoAddBillsHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src="/factura-1@2x.png" />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Agregar Factura</span>
-          </button>
+                {/* Panel colapsable (animación de altura con grid-rows) */}
+                <div
+                  className={`grid transition-all duration-300 ease-out ${
+                    isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+                  }`}
+                >
+                  <div className="overflow-hidden">
+                    <div className="ml-4 mt-1 space-y-1 border-l border-gray-200 pl-3">
+                      {section.items.map((item) => (
+                        <button
+                          key={item.path}
+                          onClick={() => go(item.path)}
+                          className={`w-full flex items-center gap-3 rounded-lg px-3 py-2 transition ${
+                            isActive(item.path)
+                              ? "bg-blue-50 text-steelblue-300 font-semibold"
+                              : "text-gray-600 hover:bg-slate-100 hover:text-gray-900"
+                          }`}
+                        >
+                          <Icon d={item.icon} className="h-[18px] w-[18px]" />
+                          <span className="text-sm">{item.label}</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            );
+          })}
 
-          <button onClick={GoCancelBill} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src={receipt} />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Invalidar factura</span>
-          </button>
-
-          <button onClick={GoClientsHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src={customers} />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Receptores</span>
-          </button>
-
-          {/* <button onClick={GoProveedoresHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <svg className="h-6 w-6 text-gray-600 group-hover:text-sky-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
-            </svg>
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Proveedores</span>
-          </button> */}
-
-          <button onClick={GoProfileHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src="/usuario-1@2x.png" />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Perfil</span>
-          </button>
-
-          <button onClick={GoBooksBill} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src={book} />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Reportes</span>
-          </button>
-
-          <button onClick={GoDownloadDTEs} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <img className="h-6 w-6 object-contain" alt="" src="/descargar@2x.png" />
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Descargar DTEs</span>
-          </button>
-
-          <button onClick={GoPagoServicio} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <svg className="h-6 w-6 text-gray-600 group-hover:text-sky-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 10h18M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z" />
-            </svg>
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Pago de servicio</span>
-          </button>
-
-          <button onClick={GoSupportChat} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-slate-100 transition group">
-            <svg className="h-6 w-6 text-gray-600 group-hover:text-sky-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h8m-8 4h5m1 5l-3 3-3-3h-2a4 4 0 01-4-4V6a4 4 0 014-4h12a4 4 0 014 4v8a4 4 0 01-4 4h-3z" />
-            </svg>
-            <span className="text-sm text-gray-800 group-hover:text-sky-700">Soporte / Chat</span>
-          </button>
-
-          {isMainAdmin && (
-            <button onClick={GoPagosAdmin} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-blue-50 transition group border border-blue-100 bg-blue-50/60">
-              <svg className="h-6 w-6 text-steelblue-300 group-hover:text-steelblue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 7h6m-6 4h6m-6 4h4M5 3h14a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V5a2 2 0 012-2z" />
-              </svg>
-              <span className="text-sm text-gray-800 group-hover:text-steelblue-300 font-semibold">Pagos (admin)</span>
-            </button>
-          )}
-
-          {isSupportAdmin && (
-            <button onClick={GoSupportAdmin} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-blue-50 transition group border border-blue-100 bg-blue-50/60">
-              <svg className="h-6 w-6 text-steelblue-300 group-hover:text-steelblue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-3.314 0-6 2.239-6 5v3h12v-3c0-2.761-2.686-5-6-5zm0 0V6m-4 0h8" />
-              </svg>
-              <span className="text-sm text-gray-800 group-hover:text-steelblue-300 font-semibold">Panel de soporte</span>
-            </button>
-          )}
-
-          <div className="pt-2 mt-2 border-t">
-            <button onClick={CloseHandler} className="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-red-50 transition group">
-              <img className="h-6 w-6 object-contain" alt="" src="/salida-1@2x.png" />
-              <span className="text-sm text-gray-800 group-hover:text-red-700">Salir</span>
+          {/* Cerrar sesión */}
+          <div className="pt-2 mt-2 border-t border-gray-100">
+            <button
+              onClick={() => go("/ingresar")}
+              className="w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-gray-700 transition hover:bg-red-50 hover:text-red-700 group"
+            >
+              <Icon d={PATHS.logout} className="h-5 w-5 text-gray-500 group-hover:text-red-600" />
+              <span className="text-sm font-semibold">Cerrar sesión</span>
             </button>
           </div>
         </nav>

--- a/dte-web-app/src/pages/AnnouncementAdmin.jsx
+++ b/dte-web-app/src/pages/AnnouncementAdmin.jsx
@@ -7,8 +7,8 @@ import AnnouncementService from '../services/AnnouncementService';
 const AnnouncementAdmin = () => {
   const token = localStorage.getItem('token');
   const currentUserId = Number(localStorage.getItem('user_id'));
-  const currentUserRole = Number(localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol'));
-  const isAdmin = currentUserId === 1 || currentUserRole === 1;
+  // Solo el usuario id 1 puede administrar el anuncio.
+  const isAdmin = currentUserId === 1;
   const navigate = useNavigate();
 
   const [message, setMessage] = useState('');

--- a/dte-web-app/src/pages/Home.jsx
+++ b/dte-web-app/src/pages/Home.jsx
@@ -16,8 +16,8 @@ const Home = () => {
   const ambiente = localStorage.getItem("ambiente");
   const userNumber = localStorage.getItem("userNumber");
   const currentUserId = Number(localStorage.getItem('user_id'));
-  const currentUserRole = Number(localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol'));
-  const isSupportAdmin = currentUserId === 1 || currentUserRole === 1;
+  // Solo el usuario id 1 es administrador (paneles de soporte, pagos y anuncios).
+  const isSupportAdmin = currentUserId === 1;
 
   // Anuncio / changelogs: se muestra una sola vez por versión a cada cliente.
   const [announcement, setAnnouncement] = useState(null);

--- a/dte-web-app/src/pages/HomeFacturas.jsx
+++ b/dte-web-app/src/pages/HomeFacturas.jsx
@@ -24,6 +24,10 @@ const buildPaymentNotice = (status) => {
 
   switch (status.state) {
     case 'al_dia':
+      // El mensaje de "al día" solo se muestra alrededor del día de pago (14, 15 y 16).
+      if (![14, 15, 16].includes(status.dayOfMonth)) {
+        return null;
+      }
       return { type: 'success', message: 'Su cuenta está al día. ¡Gracias!' };
     case 'proximo':
       return {

--- a/dte-web-app/src/pages/PagoServicio.jsx
+++ b/dte-web-app/src/pages/PagoServicio.jsx
@@ -157,8 +157,10 @@ const PagoServicio = () => {
   const TabButton = ({ id, label }) => (
     <button
       onClick={() => setTab(id)}
-      className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition ${
-        tab === id ? 'bg-white text-steelblue-300 shadow-sm' : 'text-white/80 hover:text-white'
+      className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition ${
+        tab === id
+          ? 'bg-steelblue-300 text-white shadow-sm'
+          : 'text-slate-600 hover:bg-white hover:text-slate-900'
       }`}
     >
       {label}
@@ -206,7 +208,7 @@ const PagoServicio = () => {
             </div>
 
             {/* Tabs */}
-            <div className="mb-5 flex gap-1 rounded-xl bg-steelblue-300 p-1">
+            <div className="mb-5 flex gap-1 rounded-xl border border-gray-200 bg-slate-100 p-1">
               <TabButton id="transfer" label="Transferencia" />
               <TabButton id="card" label="Tarjeta" />
               <TabButton id="history" label="Historial" />

--- a/dte-web-app/src/pages/SupportChat.jsx
+++ b/dte-web-app/src/pages/SupportChat.jsx
@@ -2,44 +2,6 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import SupportChatService from '../services/SupportChatService';
 
-const decodeJwtPayload = (token) => {
-  if (!token) {
-    return null;
-  }
-
-  const parts = token.split('.');
-  if (parts.length < 2) {
-    return null;
-  }
-
-  try {
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
-    return JSON.parse(window.atob(padded));
-  } catch (error) {
-    console.error('Error al decodificar el token', error);
-    return null;
-  }
-};
-
-const getCurrentUserRole = () => {
-  const storedRole = localStorage.getItem('user_role') || localStorage.getItem('role') || localStorage.getItem('rol');
-
-  if (storedRole !== null && storedRole !== '') {
-    const parsedRole = Number(storedRole);
-    return Number.isNaN(parsedRole) ? storedRole : parsedRole;
-  }
-
-  const token = localStorage.getItem('token');
-  const decodedToken = decodeJwtPayload(token);
-
-  if (!decodedToken) {
-    return null;
-  }
-
-  return decodedToken.role ?? decodedToken.rol ?? decodedToken.id_rol ?? decodedToken.tipo_usuario ?? decodedToken.tipoUsuario ?? decodedToken.user_role ?? null;
-};
-
 const parseMessageContent = (rawMessage) => {
   if (!rawMessage) {
     return { text: '', attachment: null };
@@ -69,8 +31,8 @@ const SupportChat = ({ mode = 'user' }) => {
   const userId = localStorage.getItem('user_id');
   const username = localStorage.getItem('username') || 'Usuario';
   const navigate = useNavigate();
-  const currentUserRole = getCurrentUserRole();
-  const isAdmin = mode === 'admin' || Number(currentUserRole) === 1 || Number(userId) === 1;
+  // Solo el usuario id 1 puede usar el panel de soporte (modo admin).
+  const isAdmin = mode === 'admin' && Number(userId) === 1;
   const currentRole = isAdmin ? 'support' : 'user';
 
   const [threads, setThreads] = useState([]);
@@ -148,6 +110,12 @@ const SupportChat = ({ mode = 'user' }) => {
       return;
     }
 
+    // El panel de soporte (modo admin) es exclusivo del usuario id 1.
+    if (mode === 'admin' && Number(userId) !== 1) {
+      navigate('/soporte');
+      return;
+    }
+
     if (!isAdmin) {
       setSelectedUserId(userId);
       loadMessages(userId);
@@ -155,7 +123,7 @@ const SupportChat = ({ mode = 'user' }) => {
     }
 
     loadThreads();
-  }, [isAdmin, navigate, token, userId]);
+  }, [isAdmin, mode, navigate, token, userId]);
 
   useEffect(() => {
     if (!selectedUserId) {


### PR DESCRIPTION
- Sidebar rediseñado como acordeon minimal (secciones colapsables con animacion de altura, iconos SVG, auto-abre la seccion de la ruta actual): Home, DTE's, Informacion, Documentos/Contabilidad, Pagos y soporte, Administracion (solo id 1) y Cerrar sesion.
- Paneles admin (soporte, pagos, anuncios) restringidos a user_id === 1 en sidebar, home y guards de pagina; SupportChat modo admin solo id 1.
- Pago de servicio: tabs (Transferencia/Tarjeta/Historial) con mejor contraste (pildora steelblue activa, resto legible).
- Notificacion "al dia" solo se muestra los dias 14, 15 y 16.