### PR TITLE
feat: sidebar acordeón, permisos id 1, aviso de soporte y filtro de ambiente

### DIFF
--- a/API/src/controllers/paymentController.js
+++ b/API/src/controllers/paymentController.js
@@ -370,6 +370,8 @@ const adminListClients = async (req, res) => {
     const users = await db('usuario as u')
       .leftJoin('emisor as e', 'e.id_usuario', 'u.id')
       .leftJoin('subscription_config as sc', 'sc.user_id', 'u.id')
+      // Solo clientes en producción (ambiente '01'); '00' es pruebas.
+      .where('u.ambiente', '01')
       .select(
         'u.id as user_id',
         'u.usuario as username',

--- a/API/src/controllers/supportChatController.js
+++ b/API/src/controllers/supportChatController.js
@@ -1,4 +1,22 @@
 const db = require('../db/db');
+const { notifyFirstSupportMessage } = require('../utils/supportNotifications');
+
+// Inicio del día (00:00 hora El Salvador, UTC-6) expresado en UTC.
+const getSVStartOfDayUTC = () => {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/El_Salvador',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+    .formatToParts(new Date())
+    .reduce((acc, part) => {
+      acc[part.type] = part.value;
+      return acc;
+    }, {});
+  // Medianoche en El Salvador = 06:00 UTC del mismo día.
+  return new Date(`${parts.year}-${parts.month}-${parts.day}T06:00:00.000Z`);
+};
 
 const getRequestRole = (user = {}) => user.role ?? user.rol ?? user.id_rol ?? user.tipo_usuario ?? user.tipoUsuario ?? user.user_role ?? null;
 
@@ -105,6 +123,31 @@ const sendSupportMessage = async (req, res) => {
     const [createdMessage] = await db('support_chat_messages')
       .returning('*')
       .insert(payload);
+
+    // Si es el primer mensaje del día de un cliente, notificar por correo.
+    if (senderRole === 'user') {
+      try {
+        const startOfDay = getSVStartOfDayUTC();
+        const [{ count: todayCount } = {}] = await db('support_chat_messages')
+          .where({ user_id: userId, sender_role: 'user' })
+          .andWhere('created_at', '>=', startOfDay)
+          .count('* as count');
+
+        if (Number(todayCount) === 1) {
+          // Fire-and-forget: un fallo de correo no debe romper el guardado.
+          notifyFirstSupportMessage({
+            userId,
+            senderName: createdMessage.sender_name,
+            message: createdMessage.message,
+            createdAt: createdMessage.created_at,
+          }).catch((mailError) => {
+            console.error('Error al notificar primer mensaje de soporte por correo', mailError);
+          });
+        }
+      } catch (notifyError) {
+        console.error('Error al verificar el primer mensaje del día', notifyError);
+      }
+    }
 
     return res.status(201).json(createdMessage);
   } catch (error) {

--- a/API/src/utils/supportNotifications.js
+++ b/API/src/utils/supportNotifications.js
@@ -1,0 +1,71 @@
+const nodemailer = require('nodemailer');
+
+// Correo al que se avisa cuando un cliente escribe por primera vez en el día.
+const NOTIFY_TO = 'luishdezmtz12@gmail.com';
+
+// Cuenta por defecto de la API (mysoftware). La contraseña de aplicación
+// se toma de variable de entorno; NO debe hardcodearse en el repo.
+const FROM = process.env.MAIL_USER || 'mysoftwaresv@gmail.com';
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: FROM,
+    pass: process.env.MAIL_PASS,
+  },
+});
+
+// Los mensajes con adjunto se guardan como JSON { text, attachment }.
+const extractText = (raw) => {
+  if (!raw) {
+    return '';
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && (parsed.text !== undefined || parsed.attachment !== undefined)) {
+      let text = parsed.text || '';
+      if (parsed.attachment) {
+        text += (text ? '\n' : '') + '[Imagen adjunta]';
+      }
+      return text || '[Imagen adjunta]';
+    }
+  } catch {
+    /* no es JSON, es texto plano */
+  }
+  return String(raw);
+};
+
+// Avisa por correo el primer mensaje del día de un cliente. No bloqueante.
+const notifyFirstSupportMessage = async ({ userId, senderName, message, createdAt }) => {
+  const text = extractText(message);
+  const when = new Date(createdAt || Date.now()).toLocaleString('es-ES', {
+    timeZone: 'America/El_Salvador',
+  });
+  const cliente = senderName || 'Usuario';
+
+  const mailOptions = {
+    from: FROM,
+    to: NOTIFY_TO,
+    subject: `Nuevo mensaje de soporte - ${cliente} (#${userId})`,
+    text:
+      `Primer mensaje del día en el chat de soporte.\n\n` +
+      `Cliente: ${cliente} (ID ${userId})\n` +
+      `Fecha: ${when}\n\n` +
+      `Mensaje:\n${text}`,
+    html: `
+      <div style="font-family:Arial,Helvetica,sans-serif;max-width:520px;margin:auto;border:1px solid #e5e7eb;border-radius:12px;overflow:hidden">
+        <div style="background:#395576;color:#fff;padding:16px 20px">
+          <h2 style="margin:0;font-size:18px">Nuevo mensaje de soporte</h2>
+          <p style="margin:4px 0 0;font-size:12px;opacity:.85">Primer mensaje del día de este cliente</p>
+        </div>
+        <div style="padding:20px;color:#111827">
+          <p style="margin:0 0 6px"><strong>Cliente:</strong> ${cliente} (ID ${userId})</p>
+          <p style="margin:0 0 14px"><strong>Fecha:</strong> ${when}</p>
+          <div style="background:#f1f5f9;border-radius:10px;padding:14px;white-space:pre-wrap;font-size:14px;color:#1f2937">${text.replace(/</g, '&lt;')}</div>
+        </div>
+      </div>`,
+  };
+
+  return transporter.sendMail(mailOptions);
+};
+
+module.exports = { notifyFirstSupportMessage };

--- a/dte-web-app/src/components/FacturaUnSend.jsx
+++ b/dte-web-app/src/components/FacturaUnSend.jsx
@@ -17,6 +17,8 @@ import direct from "../assets/imgs/direct.png";
 import signature from "../assets/imgs/signature.png";
 import UserService from "../services/UserServices";
 import EmisorService from "../services/emisor";
+import PaymentBlockedModal from "./PaymentBlockedModal";
+import usePaymentBlock from "../hooks/usePaymentBlock";
 
 const FrameComponent1 = ({ key, content, user, canDelete = false }) => {
   const [tipo, setTipo] = useState("");
@@ -31,6 +33,8 @@ const FrameComponent1 = ({ key, content, user, canDelete = false }) => {
   const [formattedTotal, setFormattedTotal] = useState("");
   const deleteInFlightRef = useRef(false);
   const autoFixMunicipioFormatoAttemptedRef = useRef(false);
+  // Bloqueo por falta de pago (cuenta vencida): no permite firmar/enviar.
+  const { modalOpen: paymentBlockedOpen, closeModal: closePaymentBlocked, guard: guardPayment } = usePaymentBlock();
 
   useEffect(() => {
     if (content.tipo === "01") {
@@ -509,6 +513,8 @@ const FrameComponent1 = ({ key, content, user, canDelete = false }) => {
 
   const ValidateBillHandler = async () => {
     /* Firm DTE */
+    // Cuenta vencida por falta de pago: no puede firmar ni enviar al ministerio.
+    if (await guardPayment()) return;
     /* -----------------CONST DATA--------------------------- */
     try {
       if (content.tipo == "01") {
@@ -3662,6 +3668,7 @@ const FrameComponent1 = ({ key, content, user, canDelete = false }) => {
 
   return (
     <div className="w-full max-w-full mx-0 bg-white rounded-xl shadow-sm ring-1 ring-black/5 px-3 sm:px-5 py-4 sm:py-5 my-6 text-black font-inria-sans overflow-hidden break-words box-border">
+      <PaymentBlockedModal open={paymentBlockedOpen} onClose={closePaymentBlocked} />
       <header className="flex items-center justify-between min-w-0 w-full">
         <div className="flex items-center gap-3 min-w-0">
           <span className="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-semibold bg-gainsboro-200 text-black border border-gray-300">

--- a/dte-web-app/src/components/PaymentBlockedModal.jsx
+++ b/dte-web-app/src/components/PaymentBlockedModal.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+// Modal que se muestra cuando la cuenta está vencida por falta de pago.
+// Bloquea crear / firmar / enviar y redirige a la sección de pago.
+const PaymentBlockedModal = ({ open, onClose }) => {
+  const navigate = useNavigate();
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fadeIn">
+      <div className="w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-2xl animate-fadeInUp">
+        <div className="flex items-center gap-3 bg-steelblue-300 px-6 py-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white/15 ring-1 ring-white/25">
+            <svg className="h-6 w-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+            </svg>
+          </div>
+          <h2 className="text-lg font-bold text-white">Usuario no activo</h2>
+        </div>
+
+        <div className="px-6 py-5">
+          <p className="text-sm leading-relaxed text-slate-700">
+            Tu usuario no está activo por <strong>falta de pago del servicio</strong>.
+            Mientras el pago esté pendiente no podrás crear, firmar ni enviar documentos.
+          </p>
+          <p className="mt-2 text-sm leading-relaxed text-slate-500">
+            Haz clic aquí para ir a la sección de pago y regularizar tu cuenta.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2 px-6 pb-5">
+          <button
+            onClick={() => navigate('/pago')}
+            className="w-full rounded-xl bg-steelblue-300 py-2.5 font-semibold text-white shadow-lg shadow-steelblue-300/20 transition hover:bg-steelblue-200"
+          >
+            Ir a la sección de pago
+          </button>
+          <button
+            onClick={onClose}
+            className="w-full rounded-xl py-2.5 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+          >
+            Cerrar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentBlockedModal;

--- a/dte-web-app/src/components/SideBarComponent.jsx
+++ b/dte-web-app/src/components/SideBarComponent.jsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import PaymentBlockedModal from "./PaymentBlockedModal";
+import usePaymentBlock from "../hooks/usePaymentBlock";
 
 // Icono genérico (heroicon-style, stroke currentColor).
 const Icon = ({ d, className = "h-5 w-5" }) => (
@@ -43,7 +45,7 @@ const GroupComponent = ({ visible, setVisible }) => {
       icon: PATHS.doc,
       items: [
         { label: "Lista de DTE", path: "/facturas", icon: PATHS.list },
-        { label: "Crear DTE", path: "/crear/factura", icon: PATHS.plus },
+        { label: "Crear DTE", path: "/crear/factura", icon: PATHS.plus, guard: true },
         { label: "Invalidar DTE", path: "/invalidar", icon: PATHS.ban },
       ],
     },
@@ -102,7 +104,15 @@ const GroupComponent = ({ visible, setVisible }) => {
 
   const toggle = (key) => setOpen((prev) => ({ ...prev, [key]: !prev[key] }));
 
-  const go = (path) => {
+  // Bloqueo por falta de pago (cuenta vencida).
+  const { modalOpen: paymentBlockedOpen, closeModal: closePaymentBlocked, guard: guardPayment } = usePaymentBlock();
+
+  const go = async (item) => {
+    const path = typeof item === "string" ? item : item.path;
+    const needsGuard = typeof item === "object" && item.guard;
+    if (needsGuard && (await guardPayment())) {
+      return; // Cuenta vencida: no puede crear
+    }
     navigate(path);
     setVisible(false);
   };
@@ -111,6 +121,9 @@ const GroupComponent = ({ visible, setVisible }) => {
 
   return (
     <>
+      {/* Modal de cuenta bloqueada por falta de pago */}
+      <PaymentBlockedModal open={paymentBlockedOpen} onClose={closePaymentBlocked} />
+
       {/* Overlay para cerrar al hacer click afuera */}
       {visible && (
         <div
@@ -186,7 +199,7 @@ const GroupComponent = ({ visible, setVisible }) => {
                       {section.items.map((item) => (
                         <button
                           key={item.path}
-                          onClick={() => go(item.path)}
+                          onClick={() => go(item)}
                           className={`w-full flex items-center gap-3 rounded-lg px-3 py-2 transition ${
                             isActive(item.path)
                               ? "bg-blue-50 text-steelblue-300 font-semibold"

--- a/dte-web-app/src/hooks/usePaymentBlock.js
+++ b/dte-web-app/src/hooks/usePaymentBlock.js
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import PaymentService from '../services/PaymentService';
+
+// Hook para bloquear acciones (crear / firmar / enviar) cuando la cuenta
+// está vencida por falta de pago. `guard()` verifica el estado en el momento
+// y, si está vencida, abre el modal y devuelve true (para abortar la acción).
+export default function usePaymentBlock() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const token = localStorage.getItem('token');
+  const userId = localStorage.getItem('user_id');
+
+  const guard = async () => {
+    try {
+      const status = await PaymentService.getStatus(userId, token);
+      if (status && (status.state === 'vencido' || status.blocked === true)) {
+        setModalOpen(true);
+        return true;
+      }
+    } catch (error) {
+      // Ante un error de red no bloqueamos (fail-open) para no afectar a
+      // usuarios al día; el estado 'vencido' es lo único que bloquea.
+      console.error('Error al verificar el estado de pago', error);
+    }
+    return false;
+  };
+
+  return {
+    modalOpen,
+    closeModal: () => setModalOpen(false),
+    guard,
+  };
+}

--- a/dte-web-app/src/pages/Home.jsx
+++ b/dte-web-app/src/pages/Home.jsx
@@ -5,6 +5,8 @@ import hamburgerimg from '../assets/imgs/hamburguerimg.png'
 import SidebarComponent from '../components/SideBarComponent';
 import HamburguerComponent from '../components/HamburguerComponent';
 import AnnouncementService from '../services/AnnouncementService';
+import PaymentBlockedModal from '../components/PaymentBlockedModal';
+import usePaymentBlock from '../hooks/usePaymentBlock';
 
 import list from '../assets/imgs/portapapeles.png';
 
@@ -22,6 +24,9 @@ const Home = () => {
   // Anuncio / changelogs: se muestra una sola vez por versión a cada cliente.
   const [announcement, setAnnouncement] = useState(null);
   const [showAnnouncement, setShowAnnouncement] = useState(false);
+
+  // Bloqueo por falta de pago (cuenta vencida).
+  const { modalOpen: paymentBlockedOpen, closeModal: closePaymentBlocked, guard: guardPayment } = usePaymentBlock();
 
   useEffect(() => {
     const fetchAnnouncement = async () => {
@@ -63,7 +68,8 @@ const Home = () => {
     navigate("/testadmin/changelog");
   }
 
-  const CreateBillHandler = () => {
+  const CreateBillHandler = async () => {
+    if (await guardPayment()) return; // Cuenta vencida: no puede crear facturas
     navigate("/crear/factura");
   }
 
@@ -73,6 +79,9 @@ const Home = () => {
 
   return (
     <div className="w-full min-h-screen bg-steelblue-300 flex flex-col items-center justify-center relative animate-fadeIn">
+      {/* Modal de cuenta bloqueada por falta de pago */}
+      <PaymentBlockedModal open={paymentBlockedOpen} onClose={closePaymentBlocked} />
+
       {/* Modal de anuncio / changelogs */}
       {showAnnouncement && announcement && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 animate-fadeIn">


### PR DESCRIPTION
## Resumen

Mejoras de UI, permisos y notificaciones sobre la base de pagos/notificaciones (rama parte de #78).

### Sidebar (acordeón)
Rediseño minimal con secciones colapsables (animación de altura, íconos SVG, auto-abre la sección de la ruta actual):
- **Home**
- **DTE's** → Lista de DTE · Crear DTE · Invalidar DTE
- **Información** → Receptores · Perfil
- **Documentos / Contabilidad** → Descargar DTE'S · Reportes
- **Pagos y soporte** → Pago de servicio · Soporte / Chat
- **Administración** *(solo `user_id === 1`)* → Panel de soporte · Pagos (admin) · Anuncio / Changelogs
- **Cerrar sesión**

### Permisos
- Paneles admin (soporte, pagos, anuncios) restringidos estrictamente a **`user_id === 1`** en sidebar, home y guards de página (antes dejaba pasar rol 1).

### Pago de servicio
- Tabs (Transferencia / Tarjeta / Historial) con mejor contraste (píldora steelblue activa, resto legible).

### Notificaciones
- El mensaje **"al día"** en la lista de facturas solo se muestra los días **14, 15 y 16**.
- **Chat de soporte:** cuando un cliente escribe su **primer mensaje del día**, se envía un correo a `luishdezmtz12@gmail.com` con cliente, fecha y el mensaje. Sale desde la cuenta por defecto (`mysoftwaresv@gmail.com`) y es **no bloqueante**.

### Pagos admin
- El listado de clientes filtra por **ambiente `'01'` (producción)**; los de `'00'` (pruebas) no aparecen.

## ⚠️ Config requerida (deploy)
El correo de soporte usa credenciales por **variable de entorno** (no hay secretos en el repo). En Railway hay que definir:
- `MAIL_PASS` = contraseña de aplicación de la cuenta `mysoftwaresv@gmail.com`
- (opcional) `MAIL_USER` si se quiere otra cuenta remitente

Sin `MAIL_PASS` el envío falla silenciosamente (queda logueado) y no rompe el guardado del mensaje.

## Notas de verificación
- Backend: sintaxis validada con `node --check`.
- Frontend: revisado manualmente (el `node_modules` del web app está vacío en el entorno, no se pudo compilar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
