### PR TITLE
feat: NRC, actividad economica y telefono del receptor en PDF de corr…

### DIFF
--- a/API/src/utils/mailUtils.js
+++ b/API/src/utils/mailUtils.js
@@ -1709,7 +1709,11 @@ const sendMail = async(userDB, plantillaDB, itemsDB) => {
                 const rows = [
                     { label: 'Nombre o razón social:', value: nombre },
                     { label: docLabel, value: numDoc },
+                    // NRC y actividad económica son opcionales en Consumidor Final: solo se muestran si existen.
+                    { label: 'NRC:', value: safeText(plantillaDB.pdf_nrc) },
+                    { label: 'Actividad económica:', value: safeText(plantillaDB.pdf_actividad_economica) },
                     { label: 'Dirección:', value: safeText(plantillaDB.re_direccion) },
+                    { label: 'Teléfono:', value: safeText(plantillaDB.re_numero_telefono) },
                     { label: 'Correo electrónico:', value: safeText(plantillaDB.re_correo_electronico) },
                 ];
                 return rows.filter(r => safeText(r.value).trim().length > 0);

--- a/API/src/utils/mailUtilsOsegueda.js
+++ b/API/src/utils/mailUtilsOsegueda.js
@@ -1098,7 +1098,11 @@ const sendMailOsegueda = async(userDB, plantillaDB, itemsDB) => {
                 const rows = [
                     { label: 'Nombre o razón social:', value: nombre },
                     { label: docLabel, value: numDoc },
+                    // NRC y actividad económica son opcionales en Consumidor Final: solo se muestran si existen.
+                    { label: 'NRC:', value: safeText(plantillaDB.pdf_nrc) },
+                    { label: 'Actividad económica:', value: safeText(plantillaDB.pdf_actividad_economica) },
                     { label: 'Dirección:', value: safeText(plantillaDB.re_direccion) },
+                    { label: 'Teléfono:', value: safeText(plantillaDB.re_numero_telefono) },
                     { label: 'Correo electrónico:', value: safeText(plantillaDB.re_correo_electronico) },
                 ];
                 return rows.filter(r => safeText(r.value).trim().length > 0);


### PR DESCRIPTION
…eo (tipo 01)

Aplica los mismos campos del receptor de la factura de consumidor final (tipo 01) en los PDFs enviados por correo: mailUtils y mailUtilsOsegueda.

- NRC (pdf_nrc) y actividad economica (pdf_actividad_economica): opcionales.
- Telefono (re_numero_telefono). Todas las filas se ocultan solas si no hay valor. No se toca la reconstruccion del JSON/QR ni el envio al Ministerio de Hacienda.