### PR TITLE
feat: editar factura tipo 01 carga y guarda NRC/actividad del PDF

### DIFF
--- a/API/src/controllers/plantillaController.js
+++ b/API/src/controllers/plantillaController.js
@@ -217,9 +217,9 @@ const plantillacreate = async(req, res) => {
             re_numero_telefono: plantilla.receptor.telefono,
             re_numdocumento: plantilla.receptor.numDocumento,
             /* NRC y actividad economica del receptor SOLO para el PDF (no se envian al MH) */
-            pdf_nrc: plantilla.receptor.pdfNrc,
-            pdf_cod_actividad: plantilla.receptor.pdfCodActividad,
-            pdf_actividad_economica: plantilla.receptor.pdfDescActividad,
+            pdf_nrc: plantilla.receptor.pdfNrc ?? null,
+            pdf_cod_actividad: plantilla.receptor.pdfCodActividad ?? null,
+            pdf_actividad_economica: plantilla.receptor.pdfDescActividad ?? null,
 
             /* --------------------------------------------------------- */
             /* OTROS DOCUMENTOS */
@@ -1734,11 +1734,12 @@ const updatePlantilla = async(req, res) => {
         if (!plantilla) {
             return res.status(404).json({ message: "plantilla no encontrado" });
         }
-        // Preservar NRC / actividad economica del PDF si la actualizacion no los trae
-        // (p.ej. al firmar, que reenvia la plantilla sin estos campos). Evita que se borren.
-        if ('pdf_nrc' in JsontoDB && JsontoDB.pdf_nrc == null) JsontoDB.pdf_nrc = plantilla.pdf_nrc ?? null;
-        if ('pdf_cod_actividad' in JsontoDB && JsontoDB.pdf_cod_actividad == null) JsontoDB.pdf_cod_actividad = plantilla.pdf_cod_actividad ?? null;
-        if ('pdf_actividad_economica' in JsontoDB && JsontoDB.pdf_actividad_economica == null) JsontoDB.pdf_actividad_economica = plantilla.pdf_actividad_economica ?? null;
+        // Preservar NRC / actividad economica del PDF SOLO si la actualizacion no los trae
+        // (undefined, p.ej. al firmar). Si el usuario los limpia al editar llegan como null
+        // y se respetan (se borran). Evita que se pierdan al firmar.
+        if ('pdf_nrc' in JsontoDB && JsontoDB.pdf_nrc === undefined) JsontoDB.pdf_nrc = plantilla.pdf_nrc ?? null;
+        if ('pdf_cod_actividad' in JsontoDB && JsontoDB.pdf_cod_actividad === undefined) JsontoDB.pdf_cod_actividad = plantilla.pdf_cod_actividad ?? null;
+        if ('pdf_actividad_economica' in JsontoDB && JsontoDB.pdf_actividad_economica === undefined) JsontoDB.pdf_actividad_economica = plantilla.pdf_actividad_economica ?? null;
         await db("plantilla")
             .where({ codigo_de_generacion: codigo_de_generacion })
             .update(JsontoDB);
@@ -2023,10 +2024,12 @@ const updatePlantillaNoItems = async(req, res) => {
             re_name: plantilla?.receptor?.nombre ?? null,
             re_numero_telefono: plantilla?.receptor?.telefono,
             re_numdocumento: plantilla?.receptor?.numDocumento ?? null,
-            /* NRC y actividad economica del receptor SOLO para el PDF (no se envian al MH) */
-            pdf_nrc: plantilla?.receptor?.pdfNrc ?? null,
-            pdf_cod_actividad: plantilla?.receptor?.pdfCodActividad ?? null,
-            pdf_actividad_economica: plantilla?.receptor?.pdfDescActividad ?? null,
+            /* NRC y actividad economica del receptor SOLO para el PDF (no se envian al MH).
+               Se dejan en undefined si la actualizacion no los trae (p.ej. al firmar) para
+               poder preservar el valor existente mas abajo; null explicito si el usuario los limpia. */
+            pdf_nrc: plantilla?.receptor?.pdfNrc,
+            pdf_cod_actividad: plantilla?.receptor?.pdfCodActividad,
+            pdf_actividad_economica: plantilla?.receptor?.pdfDescActividad,
 
             /* --------------------------------------------------------- */
             /* OTROS DOCUMENTOS */
@@ -2459,11 +2462,12 @@ const updatePlantillaNoItems = async(req, res) => {
         if (!plantilla) {
             return res.status(404).json({ message: 'plantilla no encontrado' });
         }
-        // Preservar NRC / actividad economica del PDF si la actualizacion no los trae
-        // (p.ej. al firmar, que reenvia la plantilla sin estos campos). Evita que se borren.
-        if ('pdf_nrc' in JsontoDB && JsontoDB.pdf_nrc == null) JsontoDB.pdf_nrc = plantilla.pdf_nrc ?? null;
-        if ('pdf_cod_actividad' in JsontoDB && JsontoDB.pdf_cod_actividad == null) JsontoDB.pdf_cod_actividad = plantilla.pdf_cod_actividad ?? null;
-        if ('pdf_actividad_economica' in JsontoDB && JsontoDB.pdf_actividad_economica == null) JsontoDB.pdf_actividad_economica = plantilla.pdf_actividad_economica ?? null;
+        // Preservar NRC / actividad economica del PDF SOLO si la actualizacion no los trae
+        // (undefined, p.ej. al firmar). Si el usuario los limpia al editar llegan como null
+        // y se respetan (se borran). Evita que se pierdan al firmar.
+        if ('pdf_nrc' in JsontoDB && JsontoDB.pdf_nrc === undefined) JsontoDB.pdf_nrc = plantilla.pdf_nrc ?? null;
+        if ('pdf_cod_actividad' in JsontoDB && JsontoDB.pdf_cod_actividad === undefined) JsontoDB.pdf_cod_actividad = plantilla.pdf_cod_actividad ?? null;
+        if ('pdf_actividad_economica' in JsontoDB && JsontoDB.pdf_actividad_economica === undefined) JsontoDB.pdf_actividad_economica = plantilla.pdf_actividad_economica ?? null;
         await db('plantilla').where({ codigo_de_generacion: codigo_de_generacion }).update(JsontoDB);
         res.status(200).json({ message: 'plantilla actualizado' });
     } catch (error) {

--- a/dte-web-app/src/pages/EditBill.jsx
+++ b/dte-web-app/src/pages/EditBill.jsx
@@ -67,6 +67,10 @@ const EditBill = () => {
     codActividad: "10005",
     nrc: null,
     descActividad: "Otros",
+    // Campos SOLO para el PDF (no se envían al Ministerio de Hacienda). Opcionales.
+    pdfNrc: null,
+    pdfCodActividad: null,
+    pdfDescActividad: null,
   });
 
   /* ToEdit */
@@ -154,7 +158,11 @@ const EditBill = () => {
                 responsePlantilla.plantilla[0].re_codactividad || "10005",
               nrc: responsePlantilla.plantilla[0].re_nrc || null,
               descActividad:
-                responsePlantilla.plantilla[0].re_actividad_economica || "Otros"
+                responsePlantilla.plantilla[0].re_actividad_economica || "Otros",
+              // Campos opcionales del PDF: se cargan tal cual desde la BD.
+              pdfNrc: responsePlantilla.plantilla[0].pdf_nrc || null,
+              pdfCodActividad: responsePlantilla.plantilla[0].pdf_cod_actividad || null,
+              pdfDescActividad: responsePlantilla.plantilla[0].pdf_actividad_economica || null,
             });
           } else {
             setClient({
@@ -170,6 +178,10 @@ const EditBill = () => {
               nrc: responsePlantilla.plantilla[0].re_nrc || null,
               descActividad:
                 responsePlantilla.plantilla[0].re_actividad_economica || "Otros",
+              // Campos opcionales del PDF: se cargan tal cual desde la BD.
+              pdfNrc: responsePlantilla.plantilla[0].pdf_nrc || null,
+              pdfCodActividad: responsePlantilla.plantilla[0].pdf_cod_actividad || null,
+              pdfDescActividad: responsePlantilla.plantilla[0].pdf_actividad_economica || null,
             })
           };
           const retencionDeRenta = Number(responsePlantilla.plantilla[0].retencion_de_renta);
@@ -763,6 +775,11 @@ const EditBill = () => {
         nombre: client.name,
         telefono: client.phone,
         numDocumento: client.document,
+        // Campos SOLO para el PDF (columnas pdf_* en BD). No alteran el JSON
+        // que se firma / envía al Ministerio de Hacienda.
+        pdfNrc: client.pdfNrc,
+        pdfCodActividad: client.pdfCodActividad,
+        pdfDescActividad: client.pdfDescActividad,
       },
       otrosDocumentos: null,
       ventaTercero: null,


### PR DESCRIPTION
- EditBill: el estado del cliente incluye pdfNrc/pdfCodActividad/pdfDescActividad, se cargan desde las columnas pdf_* al abrir la factura y se envian en el receptor al guardar (endpoint /update).
- Backend: en la edicion se distingue entre 'no enviado' (undefined, p.ej. al firmar -> se preserva el valor existente) y 'limpiado por el usuario' (null -> se borra). El create coerce a null para no romper el INSERT.

No se toca el JSON que se firma / envia al Ministerio de Hacienda.