### PR TITLE
feat: allow admin to confirm payments made outside the app

### DIFF
--- a/API/src/controllers/paymentController.js
+++ b/API/src/controllers/paymentController.js
@@ -129,7 +129,8 @@ const getPaymentStatus = async (req, res) => {
   try {
     const parts = getSVDateParts();
     const confirmed = await db('service_payments')
-      .where({ user_id: userId, period: parts.period, status: 'confirmed' })
+      .where({ user_id: userId, period: parts.period })
+      .whereIn('status', ['confirmed', 'paid_elsewhere'])
       .first();
 
     const paid = Boolean(confirmed);
@@ -223,7 +224,7 @@ const submitTransfer = async (req, res) => {
       .orderBy('id', 'desc')
       .first();
 
-    if (existing && existing.status === 'confirmed') {
+    if (existing && ['confirmed', 'paid_elsewhere'].includes(existing.status)) {
       return res.status(409).json({ message: 'El pago de este mes ya fue confirmado.' });
     }
 
@@ -339,7 +340,7 @@ const getTicket = async (req, res) => {
     if (!canAccess(req, payment.user_id)) {
       return res.status(403).json({ message: 'No autorizado' });
     }
-    if (payment.status !== 'confirmed') {
+    if (!['confirmed', 'paid_elsewhere'].includes(payment.status)) {
       return res.status(400).json({ message: 'El ticket solo está disponible para pagos confirmados.' });
     }
 
@@ -510,7 +511,7 @@ const adminReviewPayment = async (req, res) => {
   const paymentId = req.params.paymentId;
   const { action, note } = req.body;
 
-  if (!['confirm', 'reject'].includes(action)) {
+  if (!['confirm', 'reject', 'paid_elsewhere'].includes(action)) {
     return res.status(400).json({ message: 'Acción inválida' });
   }
 
@@ -520,10 +521,12 @@ const adminReviewPayment = async (req, res) => {
       return res.status(404).json({ message: 'Pago no encontrado' });
     }
 
+    const statusByAction = { confirm: 'confirmed', reject: 'rejected', paid_elsewhere: 'paid_elsewhere' };
+
     const update = {
-      status: action === 'confirm' ? 'confirmed' : 'rejected',
+      status: statusByAction[action],
       reviewed_by: req.user?.id || null,
-      confirmed_at: action === 'confirm' ? new Date() : null,
+      confirmed_at: action === 'confirm' || action === 'paid_elsewhere' ? new Date() : null,
       note: note ? String(note).trim() : payment.note,
       updated_at: new Date(),
     };
@@ -533,6 +536,58 @@ const adminReviewPayment = async (req, res) => {
     return res.status(200).json(updated);
   } catch (error) {
     console.error('Error al revisar el pago', error);
+    return res.status(500).json({ message: 'Error en el servidor' });
+  }
+};
+
+// Confirmar manualmente el pago de un período (sin comprobante, ej: pago físico/otro lugar).
+const adminConfirmPayment = async (req, res) => {
+  if (!isAdmin(req.user)) {
+    return res.status(403).json({ message: 'No autorizado' });
+  }
+
+  const userId = req.params.userId;
+  const { period, note, method } = req.body;
+
+  if (!period || !/^\d{4}-\d{2}$/.test(period)) {
+    return res.status(400).json({ message: 'Periodo inválido' });
+  }
+
+  try {
+    const existing = await db('service_payments')
+      .where({ user_id: userId, period })
+      .orderBy('id', 'desc')
+      .first();
+
+    if (existing && (existing.status === 'confirmed' || existing.status === 'paid_elsewhere')) {
+      return res.status(409).json({ message: 'El pago de este periodo ya fue confirmado.' });
+    }
+
+    const { amount } = await getSubscriptionAmount(userId);
+
+    const payload = {
+      user_id: userId,
+      period,
+      status: 'paid_elsewhere',
+      method: method || 'manual',
+      amount: existing ? existing.amount : amount,
+      note: note ? String(note).trim() : null,
+      reviewed_by: req.user?.id || null,
+      confirmed_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    let result;
+    if (existing) {
+      [result] = await db('service_payments').where({ id: existing.id }).update(payload).returning('*');
+    } else {
+      [result] = await db('service_payments').insert(payload).returning('*');
+    }
+
+    delete result.proof;
+    return res.status(201).json(result);
+  } catch (error) {
+    console.error('Error al confirmar el pago manualmente', error);
     return res.status(500).json({ message: 'Error en el servidor' });
   }
 };
@@ -620,6 +675,7 @@ module.exports = {
   adminListClients,
   adminGetUserPayments,
   adminReviewPayment,
+  adminConfirmPayment,
   adminSetAmount,
   adminSetSkipCertificate,
 };

--- a/API/src/routes/paymentRoutes.js
+++ b/API/src/routes/paymentRoutes.js
@@ -11,6 +11,7 @@ const {
   adminListClients,
   adminGetUserPayments,
   adminReviewPayment,
+  adminConfirmPayment,
   adminSetAmount,
   adminSetSkipCertificate,
 } = require('../controllers/paymentController');
@@ -30,6 +31,7 @@ router.get('/ticket/:paymentId', authenticateToken, getTicket);
 router.get('/admin/clients', authenticateToken, adminListClients);
 router.get('/admin/user/:userId', authenticateToken, adminGetUserPayments);
 router.put('/admin/review/:paymentId', authenticateToken, adminReviewPayment);
+router.post('/admin/confirm/:userId', authenticateToken, adminConfirmPayment);
 router.put('/admin/amount/:userId', authenticateToken, adminSetAmount);
 router.put('/admin/skip-certificate/:userId', authenticateToken, adminSetSkipCertificate);
 

--- a/dte-web-app/src/pages/PaymentsAdmin.jsx
+++ b/dte-web-app/src/pages/PaymentsAdmin.jsx
@@ -36,6 +36,8 @@ const statusMeta = (status) => {
   switch (status) {
     case 'confirmed':
       return { label: 'Recibido', cls: 'bg-emerald-100 text-emerald-700' };
+    case 'paid_elsewhere':
+      return { label: 'Pagado en otro lugar', cls: 'bg-blue-100 text-blue-700' };
     case 'pending':
       return { label: 'En revisión', cls: 'bg-amber-100 text-amber-700' };
     case 'rejected':
@@ -64,6 +66,10 @@ const PaymentsAdmin = () => {
   const [proofLoading, setProofLoading] = useState(false);
   const [skipCertificateDraft, setSkipCertificateDraft] = useState(false);
   const [savingSkipCertificate, setSavingSkipCertificate] = useState(false);
+  const [paidElsewhereModal, setPaidElsewhereModal] = useState(null); // { paymentId, note }
+  const [savingPaidElsewhere, setSavingPaidElsewhere] = useState(false);
+  const [confirmingCurrentPayment, setConfirmingCurrentPayment] = useState(false);
+  const [currentPaymentNote, setCurrentPaymentNote] = useState('');
 
   const loadClients = async (targetPeriod) => {
     setLoading(true);
@@ -117,17 +123,49 @@ const PaymentsAdmin = () => {
     }
   };
 
-  const handleReview = async (paymentId, action) => {
+  const handleReview = async (paymentId, action, note) => {
     setReviewingId(paymentId);
     try {
-      await PaymentService.adminReview(paymentId, token, action);
-      toast.success(action === 'confirm' ? 'Pago confirmado' : 'Pago rechazado');
+      await PaymentService.adminReview(paymentId, token, action, note);
+      const messages = {
+        confirm: 'Pago confirmado',
+        reject: 'Pago rechazado',
+        paid_elsewhere: 'Pago confirmado en otro lugar'
+      };
+      toast.success(messages[action] || 'Pago actualizado');
       await refreshAfterChange();
     } catch (error) {
       console.error('Error al revisar el pago', error);
       toast.error(error?.message || 'No se pudo actualizar el pago');
     } finally {
       setReviewingId(null);
+    }
+  };
+
+  const handlePaidElsewhere = async () => {
+    if (!paidElsewhereModal) return;
+    setSavingPaidElsewhere(true);
+    try {
+      await handleReview(paidElsewhereModal.paymentId, 'paid_elsewhere', paidElsewhereModal.note);
+      setPaidElsewhereModal(null);
+    } finally {
+      setSavingPaidElsewhere(false);
+    }
+  };
+
+  const handleConfirmCurrentPayment = async () => {
+    if (!selected) return;
+    setConfirmingCurrentPayment(true);
+    try {
+      await PaymentService.adminConfirmPayment(selected.user_id, token, period, currentPaymentNote);
+      toast.success('Pago confirmado para este período');
+      setCurrentPaymentNote('');
+      await refreshAfterChange();
+    } catch (error) {
+      console.error('Error al confirmar pago', error);
+      toast.error(error?.message || 'No se pudo confirmar el pago');
+    } finally {
+      setConfirmingCurrentPayment(false);
     }
   };
 
@@ -326,6 +364,32 @@ const PaymentsAdmin = () => {
               )}
             </div>
 
+            {/* Confirmar pago del período actual sin comprobante */}
+            <div className="mb-5 rounded-xl border border-gray-100 p-4">
+              <label className="mb-3 block text-sm font-semibold text-slate-900">Confirmar pago de {period ? labelFor(period) : 'este período'}</label>
+              <p className="mb-3 text-sm text-slate-600">
+                Confirma que el cliente pagó en este período (ej: depósito físico, efectivo, etc.)
+              </p>
+              <textarea
+                value={currentPaymentNote}
+                onChange={(e) => setCurrentPaymentNote(e.target.value)}
+                placeholder="Cómo pagó (ej: Depósito bancario, Efectivo, Transferencia personal, etc.)"
+                maxLength={250}
+                className="mb-3 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-slate-800 outline-none focus:border-steelblue-200 focus:ring-2 focus:ring-steelblue-100"
+                rows={3}
+              />
+              <p className="mb-3 text-xs text-slate-500">
+                {currentPaymentNote.length}/250 caracteres
+              </p>
+              <button
+                onClick={handleConfirmCurrentPayment}
+                disabled={confirmingCurrentPayment || !currentPaymentNote.trim()}
+                className="rounded-lg bg-steelblue-300 px-4 py-2 text-sm font-semibold text-white transition hover:bg-steelblue-200 disabled:opacity-60"
+              >
+                {confirmingCurrentPayment ? 'Confirmando...' : 'Confirmar pago'}
+              </button>
+            </div>
+
             {/* Historial de pagos */}
             <p className="mb-2 text-sm font-semibold text-slate-900">Historial</p>
             {detailLoading ? (
@@ -362,14 +426,22 @@ const PaymentsAdmin = () => {
                             Ver comprobante
                           </button>
                         )}
-                        {p.status !== 'confirmed' && (
-                          <button
-                            onClick={() => handleReview(p.id, 'confirm')}
-                            disabled={reviewingId === p.id}
-                            className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-400 disabled:opacity-60"
-                          >
-                            {reviewingId === p.id ? '...' : 'Confirmar recibido'}
-                          </button>
+                        {p.status !== 'confirmed' && p.status !== 'paid_elsewhere' && (
+                          <>
+                            <button
+                              onClick={() => handleReview(p.id, 'confirm')}
+                              disabled={reviewingId === p.id}
+                              className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-emerald-400 disabled:opacity-60"
+                            >
+                              {reviewingId === p.id ? '...' : 'Confirmar recibido'}
+                            </button>
+                            <button
+                              onClick={() => setPaidElsewhereModal({ paymentId: p.id, note: '' })}
+                              className="rounded-lg border border-blue-200 px-3 py-1.5 text-xs font-semibold text-blue-600 transition hover:bg-blue-50"
+                            >
+                              Pago en otro lugar
+                            </button>
+                          </>
                         )}
                         {p.status === 'pending' && (
                           <button
@@ -380,7 +452,7 @@ const PaymentsAdmin = () => {
                             Rechazar
                           </button>
                         )}
-                        {p.status === 'confirmed' && (
+                        {(p.status === 'confirmed' || p.status === 'paid_elsewhere') && (
                           <button
                             onClick={() => handleDownloadTicket(p.id)}
                             className="rounded-lg bg-steelblue-300 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-steelblue-200"
@@ -441,6 +513,50 @@ const PaymentsAdmin = () => {
         >
           <div className="max-h-[90vh] max-w-3xl overflow-auto rounded-xl bg-white p-2" onClick={(e) => e.stopPropagation()}>
             <img src={proofView.data} alt={proofView.name || 'Comprobante'} className="h-auto w-full rounded-lg" />
+          </div>
+        </div>
+      )}
+
+      {/* Modal de pago en otro lugar */}
+      {paidElsewhereModal && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4"
+          onClick={() => setPaidElsewhereModal(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl bg-white p-6 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="mb-4 text-lg font-semibold text-slate-900">Confirmar pago en otro lugar</h3>
+            <p className="mb-4 text-sm text-slate-600">
+              Describe dónde y cómo se realizó el pago (ej: "Depósito bancario", "Efectivo", etc.)
+            </p>
+            <textarea
+              value={paidElsewhereModal.note}
+              onChange={(e) => setPaidElsewhereModal({ ...paidElsewhereModal, note: e.target.value })}
+              placeholder="Detalles del pago..."
+              maxLength={250}
+              className="mb-4 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm text-slate-800 outline-none focus:border-blue-200 focus:ring-2 focus:ring-blue-100"
+              rows={4}
+            />
+            <p className="mb-4 text-xs text-slate-500">
+              {paidElsewhereModal.note.length}/250 caracteres
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPaidElsewhereModal(null)}
+                className="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-50"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={handlePaidElsewhere}
+                disabled={savingPaidElsewhere || !paidElsewhereModal.note.trim()}
+                className="flex-1 rounded-lg bg-blue-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-blue-400 disabled:opacity-60"
+              >
+                {savingPaidElsewhere ? '...' : 'Confirmar'}
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/dte-web-app/src/services/PaymentService.js
+++ b/dte-web-app/src/services/PaymentService.js
@@ -106,6 +106,15 @@ const PaymentService = {
     });
     return parseJson(res);
   },
+
+  adminConfirmPayment: async (userId, token, period, note) => {
+    const res = await fetch(`${BASE_URL}/payments/admin/confirm/${userId}`, {
+      method: 'POST',
+      headers: { ...authHeaders(token), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ period, note, method: 'manual' }),
+    });
+    return parseJson(res);
+  },
 };
 
 export default PaymentService;


### PR DESCRIPTION
Adds a "paid elsewhere" flow so admins can manually confirm a client's payment for the current period even without a submitted proof (e.g. cash or in-person transfer), plus support for marking existing pending payments as paid elsewhere.